### PR TITLE
Schema Less Queries

### DIFF
--- a/3.0.0/bc_subquery.gsql
+++ b/3.0.0/bc_subquery.gsql
@@ -42,7 +42,6 @@ CREATE QUERY bc_subquery (VERTEX source, SET<STRING> v_type, SET<STRING> e_type,
 	            @@MapDelta += (s->s.@delta/2)
 	          ELSE @@MapDelta += (s->0)
 	          END;
-
+  
 	return @@MapDelta;
-
  }

--- a/3.0.0/bc_subquery.gsql
+++ b/3.0.0/bc_subquery.gsql
@@ -1,0 +1,48 @@
+CREATE QUERY bc_subquery (VERTEX source, SET<STRING> v_type, SET<STRING> e_type, INT max_hops) RETURNS(MapAccum<VERTEX, FLOAT>) {
+/* The TigerGraph implementation is based on A Faster Algorithm for Betweenness Centrality by Ulrik Brandes, Journal of Mathematical Sociology 25(2):163-177, (2001). According to the algorithm, sigma is the number of shortest paths from source; delta is the pair dependency from source; and dist is the shortest distance from source. The subquery returns a map of (s.id->s.@delta)
+*/
+  SumAccum<FLOAT> @sigma;              
+	SumAccum<FLOAT> @delta;              
+	MaxAccum<INT> @dist;                 
+	SumAccum<INT> @@currDist = 0;
+	MapAccum<VERTEX, FLOAT> @@MapDelta;   
+	
+	All = {v_type};
+	Start = {source};
+	Start = SELECT s FROM Start:s 
+	        ACCUM s.@sigma = 1, s.@dist = 0;
+ 
+# traverse in the order of increasing distance and calculate @sigma and @dist
+	WHILE (Start.size()>0) LIMIT max_hops DO		# explore up to (maxHops) hops FROM s
+	  @@currDist += 1;
+	  Start = SELECT t FROM Start:s-(e_type:e)->:t
+	          WHERE t.@dist < 0
+	          ACCUM t.@sigma += s.@sigma,
+	                t.@dist = @@currDist;  
+	END;
+  
+	@@currDist += -1;
+	Start = SELECT s FROM All:s
+	        WHERE s.@dist == @@currDist;
+	
+# traverse in the order of non-increasing distance and calculate @delta
+	WHILE (@@currDist>0) DO
+	  @@currDist += -1;
+	  Start = SELECT s FROM Start:s -(e_type:e)->:t
+	          WHERE t.@dist == s.@dist-1
+	          ACCUM t.@delta += t.@sigma/s.@sigma*(1+s.@delta);
+	          
+	  Start = SELECT s FROM All:s
+	          WHERE s.@dist == @@currDist;	         
+	END;
+	
+	Start = SELECT s FROM All:s
+	        ACCUM
+	          CASE WHEN s!=source THEN
+	            @@MapDelta += (s->s.@delta/2)
+	          ELSE @@MapDelta += (s->0)
+	          END;
+
+	return @@MapDelta;
+
+ }

--- a/3.0.0/betweenness_cent.gsql
+++ b/3.0.0/betweenness_cent.gsql
@@ -2,20 +2,25 @@ CREATE QUERY betweenness_cent(SET<STRING> v_type, SET<STRING> e_type, INT max_ho
 # Betweenness Centrality main query
 
 	MapAccum<VERTEX,SumAccum<FLOAT>> @@BC;
+  SumAccum<FLOAT> @score;
   FILE f (file_path);
   Start = {v_type};
+  
   
   IF file_path != "" THEN
      f.println("Vertex_ID", "Betweenness");
   END;
   
   Start = SELECT s FROM Start:s
-          ACCUM @@BC += bc_subquery(s, v_type,e_type, max_hops), 
-          IF file_path != "" THEN f.println(s, @@BC.get(s)) END
-          POST-ACCUM IF attr != "" THEN s.setAttr(attr, @@BC.get(s)) END;
-        
+          ACCUM @@BC += bc_subquery(s, v_type,e_type, max_hops)
+          POST-ACCUM 
+            INT a = @@BC.get(s) * 100,
+            s.@score = a / 100.0,
+            IF attr != "" THEN s.setAttr(attr, @@BC.get(s)) END,  
+            IF file_path != "" THEN f.println(s, @@BC.get(s)) END;
+     
   
   IF print_accum THEN
-    PRINT @@BC;
+    PRINT Start[Start.@score];
   END;
 }

--- a/3.0.0/betweenness_cent.gsql
+++ b/3.0.0/betweenness_cent.gsql
@@ -14,8 +14,7 @@ CREATE QUERY betweenness_cent(SET<STRING> v_type, SET<STRING> e_type, INT max_ho
   Start = SELECT s FROM Start:s
           ACCUM @@BC += bc_subquery(s, v_type,e_type, max_hops)
           POST-ACCUM 
-            INT a = @@BC.get(s) * 100,
-            s.@score = a / 100.0,
+            s.@score = @@BC.get(s),
             IF attr != "" THEN s.setAttr(attr, @@BC.get(s)) END,  
             IF file_path != "" THEN f.println(s, @@BC.get(s)) END;
      

--- a/3.0.0/betweenness_cent.gsql
+++ b/3.0.0/betweenness_cent.gsql
@@ -1,0 +1,21 @@
+CREATE QUERY betweenness_cent(SET<STRING> v_type, SET<STRING> e_type, INT max_hops = 10,  BOOL print_accum=TRUE, STRING attr="", STRING file_path=""){
+# Betweenness Centrality main query
+
+	MapAccum<VERTEX,SumAccum<FLOAT>> @@BC;
+  FILE f (file_path);
+  Start = {v_type};
+  
+  IF file_path != "" THEN
+     f.println("Vertex_ID", "Betweenness");
+  END;
+  
+  Start = SELECT s FROM Start:s
+          ACCUM @@BC += bc_subquery(s, v_type,e_type, max_hops), 
+          IF file_path != "" THEN f.println(s, @@BC.get(s)) END
+          POST-ACCUM IF attr != "" THEN s.setAttr(attr, @@BC.get(s)) END;
+        
+  
+  IF print_accum THEN
+    PRINT @@BC;
+  END;
+}

--- a/3.0.0/cc_subquery.gsql
+++ b/3.0.0/cc_subquery.gsql
@@ -1,0 +1,31 @@
+CREATE QUERY cc_subquery (VERTEX source, SET<STRING> e_type, INT num_vert, INT max_hops, BOOL wf = TRUE)  RETURNS(FLOAT) {
+# Subquery returns closeness centrality for vertex source in graph with numVert vertices 
+        SumAccum<INT> @@currDist, @@totalDist, @@n;
+        OrAccum<BOOL> @visited;
+ 
+# Initialize: Set the input vertex source as the starting point
+        Start = {source};
+        Start = SELECT s FROM Start:s
+                ACCUM s.@visited += true;
+ 
+# totalDist = sum (distance between vertex s and all connected neighbors)
+        WHILE (Start.size() > 0) LIMIT max_hops DO    # explore up to (maxHops) hops FROM s
+                @@currDist += 1;
+                # Move FROM the current start set to the neighboring set of (unvisited) vertices
+                Start = SELECT t FROM Start:s -(e_type:e)-> :t
+                        WHERE t.@visited == false AND t != s
+                        POST-ACCUM t.@visited += true;
+                                   @@totalDist += Start.size() * @@currDist;
+				   @@n += Start.size();
+        END;
+ 
+        IF @@totalDist > 0 THEN
+	          IF wf == TRUE THEN
+                        RETURN (@@n*1.0/(num_vert-1))*(@@n*1.0/@@totalDist);
+	          ELSE 
+                        RETURN (@@n*1.0/@@totalDist);
+	          END;
+        ELSE
+                RETURN (-1.0);
+        END;
+ }

--- a/3.0.0/closeness_cent.gsql
+++ b/3.0.0/closeness_cent.gsql
@@ -1,0 +1,36 @@
+CREATE QUERY closeness_cent(SET<STRING> v_type, SET<STRING> e_type, INT output_limit, BOOL wf = TRUE, BOOL print_accum = True, STRING attr = "", STRING file_path = "", BOOL display = FALSE){
+  
+        TYPEDEF TUPLE<VERTEX Vertex_ID, FLOAT score> VertexScore;
+        HeapAccum<VertexScore>(output_limit, score DESC) @@topScores;
+        SumAccum<FLOAT> @score;
+        SetAccum<EDGE> @@edgeSet;
+        FILE f (file_path);
+  
+        INT numVert;
+        INT maxHops = 10;      # measure distance for vertices up to 10 hops away
+        Start = {v_type};
+        numVert = Start.size();
+        
+  
+        IF file_path != "" THEN
+          f.println("Vertex_ID", "Closeness");
+        END;
+
+        Start = SELECT s FROM Start:s
+                POST-ACCUM s.@score = cc_subquery(s, e_type, numVert, maxHops, wf),
+                            IF attr != "" THEN  s.setAttr(attr, s.@score) END,
+                            IF print_accum THEN @@topScores += VertexScore(s, s.@score) END,
+                            IF file_path != "" THEN f.println(s, s.@score) END
+                LIMIT output_limit;
+  
+        IF print_accum THEN
+          PRINT @@topScores AS top_scores;
+          IF display THEN
+                PRINT Start[Start.@score];
+                Start = SELECT s
+                FROM Start:s -(e_type:e)->:t
+                    ACCUM @@edgeSet += e;
+                PRINT @@edgeSet;
+        END;
+        END;
+}

--- a/3.0.0/conn_comp.gsql
+++ b/3.0.0/conn_comp.gsql
@@ -1,0 +1,41 @@
+CREATE QUERY conn_comp (SET<STRING> v_type, SET<STRING> e_type, INT output_limit, BOOL print_accum = TRUE, STRING attr = "", STRING file_path = ""){
+# This query identifies the Connected Components (undirected edges)
+
+        MinAccum<INT> @cc_id = 0;       //each vertex's tentative component id
+        MapAccum<INT, INT> @@compSizes;
+        FILE f(file_path); 
+  
+        Start = {v_type};
+
+# Initialize: Label each vertex with its own internal ID
+        S = SELECT x 
+            FROM Start:x
+            POST-ACCUM x.@cc_id = getvid(x)
+                       ;
+
+# Propagate smaller internal IDs until no more ID changes can be DOne
+        WHILE (S.size()>0) DO
+                S = SELECT t
+                        FROM S:s -(e_type:e)-> :t
+                        ACCUM t.@cc_id += s.@cc_id // If s has a smaller id than t, copy the id to t
+                        HAVING t.@cc_id != t.@cc_id'
+                        ;
+        END;
+  
+      IF file_path != "" THEN
+          f.println("Vertex_ID","Component_ID");
+      END;
+        
+        Start = {v_type};
+        Start = SELECT s FROM Start:s
+                POST-ACCUM 
+                    IF attr != "" THEN s.setAttr(attr, s.@cc_id) END,
+                    IF print_accum THEN @@compSizes += (s.@cc_id -> 1) END,
+                    IF file_path != "" THEN f.println(s, s.@cc_id) END
+                LIMIT output_limit;
+      
+      IF print_accum THEN
+          PRINT @@compSizes as sizes;
+          PRINT Start[Start.@cc_id];
+      END;
+}

--- a/3.0.0/cosine_nbor_ap.gsql
+++ b/3.0.0/cosine_nbor_ap.gsql
@@ -1,0 +1,22 @@
+CREATE QUERY cosine_nbor_ap (SET<STRING> v_type, SET<STRING> e_type, SET<STRING> re_type, STRING weight, INT top_k, INT output_limit, BOOL print_accum = TRUE, STRING similarity_edge = "", STRING file_path = ""){
+/* This query calls the subquery cosine_nbor_ap_sub to get the similarity score of every pair of vertices.
+*/
+        MapAccum<VERTEX, FLOAT> @result;
+        FILE f (file_path);
+        start = {v_type};
+        
+        IF file_path != "" THEN
+         f.println("Vertex1","Vertex2","Similarity");
+        END;
+   
+        start = SELECT s
+                FROM start:s
+                POST-ACCUM 
+                   IF print_accum THEN s.@result = cosine_nbor_ap_sub(s, e_type, re_type, weight, top_k, TRUE, similarity_edge, file_path, f)
+                   ELSE cosine_nbor_ap_sub(s, e_type, re_type, weight, top_k, FALSE, similarity_edge, file_path, f) END
+                LIMIT output_limit;
+        
+        IF print_accum THEN
+           PRINT start[start.@result];
+        END;
+}

--- a/3.0.0/cosine_nbor_ap_sub.gsql
+++ b/3.0.0/cosine_nbor_ap_sub.gsql
@@ -1,0 +1,35 @@
+CREATE QUERY cosine_nbor_ap_sub (VERTEX source, SET<STRING> e_type, SET<STRING> re_type, STRING weight, INT top_k, BOOL store_accum, STRING similarity_edge, STRING file_path, FILE f) RETURNS (MapAccum<VERTEX, FLOAT>){
+/* This subquery calculates the Cosine Similarity between a given vertex and every other vertex.
+Cosine similarity = A \dot B / ||A|| \dot ||B||
+*/
+  
+         MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
+
+        start = {source};
+        subjects = SELECT t
+                   FROM start:s -(e_type:e)->:t
+                   ACCUM t.@numerator = e.getAttr(weight, "FLOAT"),
+                         @@norm1 += pow(e.getAttr(weight, "FLOAT"), 2);
+
+        neighbours = SELECT t
+                     FROM subjects:s -(re_type:e)->:t
+                     WHERE t != source
+                     ACCUM t.@numerator += s.@numerator * e.getAttr(weight, "FLOAT");
+
+        neighbours = SELECT s
+                     FROM neighbours:s -(e_type:e)-> :t
+                     ACCUM s.@norm2 += pow(e.getAttr(weight, "FLOAT"), 2)
+                     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT top_k;
+  
+        neightbours = SELECT s
+                      FROM neighbours:s
+                      POST-ACCUM 
+                      IF similarity_edge != "" THEN INSERT INTO EDGE similarity_edge VALUES(source, s, s.@similarity) END,
+                      IF store_accum THEN @@topK_result += (s -> s.@similarity) END,
+                      IF file_path != "" THEN f.println(source, s, s.@similarity) END;
+                      
+        return @@topK_result;
+}

--- a/3.0.0/cosine_nbor_ss.gsql
+++ b/3.0.0/cosine_nbor_ss.gsql
@@ -1,0 +1,40 @@
+CREATE QUERY cosine_nbor_ss (VERTEX source, SET<STRING> e_type, SET<STRING> re_type, STRING weight, INT top_k, INT output_limit, BOOL print_accum = TRUE, STRING file_path = "", STRING similarity_edge = "") RETURNS (MapAccum<VERTEX, FLOAT>) {	
+/* This query calculates the Cosine Similarity between a given vertex and every other vertex.	
+Cosine similarity = A \dot B / ||A|| \dot ||B||	
+*/	
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;	
+        MapAccum<VERTEX, FLOAT> @@topK_result;	
+        FILE f (file_path);
+  
+  
+        start = {source};	
+        subjects = SELECT t	
+                   FROM start:s -(e_type:e)-> :t	
+                   ACCUM t.@numerator = e.getAttr(weight, "FLOAT"),	
+                         @@norm1 += pow(e.getAttr(weight, "FLOAT"), 2);	
+
+        neighbours = SELECT t	
+                     FROM subjects:s -(re_type:e)->:t	
+                     WHERE t != source	
+                     ACCUM t.@numerator += s.@numerator * e.getAttr(weight, "FLOAT");	
+
+        neighbours = SELECT s	
+                     FROM neighbours:s -(e_type:e)-> :t	
+                     ACCUM s.@norm2 += pow(e.getAttr(weight, "FLOAT"), 2)	
+        	     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)	
+                     ORDER BY s.@similarity DESC	
+                     LIMIT top_k;	
+      neighbours = SELECT s
+                  FROM neighbours:s
+                  POST-ACCUM 
+                    IF similarity_edge != "" THEN INSERT INTO EDGE similarity_edge VALUES(source, s, s.@similarity) END,
+                    IF file_path != "" THEN f.println(source, s, s.@similarity) END,
+                    IF print_accum THEN @@topK_result += (s -> s.@similarity) END 
+                  LIMIT output_limit;
+    
+      IF print_accum THEN
+        PRINT neighbours[neighbours.@similarity];
+      END;
+  
+      RETURN @@topK_result;
+}

--- a/3.0.0/cycle_detection.gsql
+++ b/3.0.0/cycle_detection.gsql
@@ -1,0 +1,50 @@
+CREATE QUERY cycle_detection (SET<STRING> v_type, SET<STRING> e_type, INT depth, BOOL print_accum = TRUE, STRING file_path = ""){
+
+/* Rocha–Thatte cycle detection algorithm
+This is a distributed algorithm for detecting all the cycles on large-scale directed graphs.In every iteration, the vertices send its sequences to its out-neighbors, and receive the sequences from the in-neighbors.
+Stop passing the sequence (v1,v2,v3, ...) when:
+1. v = v1. If v has the minimum label in the sequence, report the cycle
+2. v = vi (i!=1). Do not report since this cycle is already reported in an earlier iteration
+*/
+        ListAccum<ListAccum<VERTEX>> @currList, @newList;
+        ListAccum<ListAccum<VERTEX>> @@cycles;
+        SumAccum<INT> @uid;
+        FILE f (file_path);
+  
+        # initialization
+        Active = {v_type};
+        Active = SELECT s 
+                 FROM Active:s
+                 ACCUM s.@currList = [s];
+  
+        WHILE Active.size() > 0 LIMIT depth DO 
+        Active = SELECT t 
+                 FROM Active:s -(e_type:e)-> :t
+                 ACCUM 
+                       FOREACH sequence IN s.@currList DO
+                               BOOL t_is_min = TRUE, 
+                               IF t == sequence.get(0) THEN  # cycle detected
+                                        FOREACH v IN sequence DO
+                                                IF getvid(v) < getvid(t) THEN
+                                                        t_is_min = FALSE,
+                                                        BREAK
+                                                END
+                                        END,
+                                        IF t_is_min == TRUE THEN  # if it has the minimal label in the list, report 
+                                               IF print_accum THEN @@cycles += sequence END,
+                                               IF file_path != "" THEN f.println(sequence) END
+                                        END
+                               ELSE IF sequence.contains(t) == FALSE THEN   # discard the sequences contain t
+                                        t.@newList += [sequence + [t]]   # store sequences in @newList to avoid confliction with @currList
+                               END
+                       END
+                 POST-ACCUM s.@currList.clear(),
+                            t.@currList = t.@newList,
+                            t.@newList.clear()
+                 HAVING t.@currList.size() > 0;  # IF receive no sequences, deactivate it;
+        END;
+
+IF print_accum THEN
+    PRINT @@cycles as cycles;
+END;  
+}

--- a/3.0.0/estimate_diameter.gsql
+++ b/3.0.0/estimate_diameter.gsql
@@ -1,11 +1,12 @@
-CREATE QUERY estimate_diameter(SET<STRING> v_type, SET<STRING> e_type, INT seed_set_length, BOOL print_accum = TRUE, STRING file_path = "", BOOL display = FALSE) {
+CREATE QUERY estimate_diameter(SET<STRING> v_type, SET<STRING> e_type, INT seed_set_length, BOOL print_accum = TRUE, STRING file_path = "", BOOL display = FALSE){
+  
         MaxAccum<INT> @@diameter;
         FILE f (file_path);
   
         start = {v_type};
+  
         start = SELECT s
                 FROM start:s
-                ORDER BY getvid(s)
                 LIMIT seed_set_length;
   
         IF display THEN

--- a/3.0.0/estimate_diameter.gsql
+++ b/3.0.0/estimate_diameter.gsql
@@ -1,0 +1,27 @@
+CREATE QUERY estimate_diameter(SET<STRING> v_type, SET<STRING> e_type, INT seed_set_length, BOOL print_accum = TRUE, STRING file_path = "", BOOL display = FALSE) {
+        MaxAccum<INT> @@diameter;
+        FILE f (file_path);
+  
+        start = {v_type};
+        start = SELECT s
+                FROM start:s
+                ORDER BY getvid(s)
+                LIMIT seed_set_length;
+  
+        IF display THEN
+          	PRINT start;
+        END;
+  
+        start = SELECT s
+                FROM start:s
+                ACCUM @@diameter += max_BFS_depth(s, e_type);
+        
+        IF print_accum THEN
+          PRINT @@diameter as diameter;
+        END;
+  
+        IF file_path != "" THEN
+          f.println("Diameter");
+          f.println(@@diameter);
+        END;
+}

--- a/3.0.0/jaccard_nbor_ap.gsql
+++ b/3.0.0/jaccard_nbor_ap.gsql
@@ -1,0 +1,25 @@
+CREATE QUERY jaccard_nbor_ap(STRING v_type, STRING e_type, STRING re_type, INT top_k, BOOL print_accum = TRUE, STRING similarity_edge = "", STRING file_path = ""){
+/* This query calls the subquery jaccard_nbor_ap_sub to get the similarity score of every pair of vertices.
+
+  This query supports only taking in a single edge for the time being (8/13/2020).
+*/
+        MapAccum<VERTEX, FLOAT> @result;
+        FILE f (file_path);
+  
+        start = {v_type};
+        IF file_path != "" THEN
+          f.println("Vertex1", "Vertex2", "Similarity");
+        END;
+        start = SELECT s
+                FROM start:s
+                POST-ACCUM 
+                IF print_accum THEN
+                  s.@result = jaccard_nbor_ap_sub(s, e_type, re_type, top_k, TRUE, file_path,f, similarity_edge)
+                ELSE
+                  jaccard_nbor_ap_sub(s, e_type, re_type, top_k, TRUE, file_path,f, similarity_edge)
+                END;
+  
+        IF print_accum THEN
+          PRINT start[start.@result];
+        END;
+}

--- a/3.0.0/jaccard_nbor_ap_sub.gsql
+++ b/3.0.0/jaccard_nbor_ap_sub.gsql
@@ -1,0 +1,34 @@
+CREATE QUERY jaccard_nbor_ap_sub(VERTEX source, STRING e_type, STRING re_type, INT top_k, BOOL return_accum, STRING file_path, FILE f, STRING similarity_edge) RETURNS (MapAccum<VERTEX, FLOAT>){
+/* This subquery calculates the Jaccard Similarity between a given vertex and every other vertex.
+Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
+*/
+    
+        MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
+
+        Start (ANY) = {source};
+        Start = SELECT s
+                FROM Start:s
+                ACCUM @@set_size_A += s.outdegree(e_type);
+
+        Subjects = SELECT t
+                   FROM Start:s-(e_type:e)-:t;
+
+        Others = SELECT t
+                 FROM Subjects:s -(re_type:e)- :t
+                 WHERE t != source 
+                 ACCUM t.@intersection_size += 1, 
+                       t.@set_size_B = t.outdegree(e_type)
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT top_k;
+        
+        Others =  SELECT s
+                  FROM Others: s
+                  POST-ACCUM 
+                      IF similarity_edge != "" THEN INSERT INTO EDGE similarity_edge VALUES(source, s, s.@similarity) END,
+                      IF file_path != "" THEN f.println(source, s, s.@similarity) END,
+                      IF return_accum THEN @@topK_result += (s -> s.@similarity) END;
+      return @@topK_result;
+}

--- a/3.0.0/jaccard_nbor_ss.gsql
+++ b/3.0.0/jaccard_nbor_ss.gsql
@@ -1,0 +1,44 @@
+CREATE QUERY jaccard_nbor_ss (VERTEX source, STRING e_type, STRING re_type, INT top_k, BOOL print_accum = TRUE, STRING file_path = "", STRING similarity_edge = ""){
+
+/* 
+This query calculates the Jaccard Similarity between a given vertex and every other vertex.
+Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
+
+This query supports only taking in a single edge for the time being (8/13/2020).
+*/
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
+        FILE f (file_path);
+
+        Start (ANY) = {source};
+        Start = SELECT s
+        	FROM Start:s
+                ACCUM @@set_size_A += s.outdegree(e_type);
+
+        Subjects = SELECT t
+                   FROM Start:s-(e_type:e)-:t;
+
+        Others = SELECT t
+                 FROM Subjects:s -(re_type:e)- :t
+                 WHERE t != source
+                 ACCUM t.@intersection_size += 1,
+                       t.@set_size_B = t.outdegree(e_type)
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT top_k;
+        
+        IF file_path != "" THEN
+            f.println("Vertex1", "Vertex2", "Similarity");
+        END;
+  
+
+        Others = SELECT s
+                 FROM Others:s
+                 POST-ACCUM 
+                    IF similarity_edge != "" THEN INSERT INTO EDGE similarity_edge VALUES(source, s, s.@similarity) END,
+                    IF file_path != "" THEN f.println(source, s, s.@similarity) END; 
+
+        IF print_accum THEN
+            PRINT Others[Others.@similarity];
+        END;
+}

--- a/3.0.0/kcore.gsql
+++ b/3.0.0/kcore.gsql
@@ -3,7 +3,7 @@ CREATE QUERY kcore(STRING v_type, STRING e_type, INT k_min = 0, INT k_max = -1, 
  * Scalable K-Core Decomposition for Static Graphs Using a Dynamic Graph Data Structure,
  * Tripathy et al., IEEE Big Data 2018.
  
-  This query supports only taking in a single edge for the time being (8/13/2020).
+ This query is only supported for a single edge type at the moment (8/13/20)
  */
 	SumAccum<INT> @deg;        // The number of edges v has to active vertices.
   SumAccum<INT> @core;       // The core level of vertex v
@@ -18,7 +18,7 @@ CREATE QUERY kcore(STRING v_type, STRING e_type, INT k_min = 0, INT k_max = -1, 
   
   
 	Q = active;
-	WHILE active.size() > 0 AND (k_max == -1 OR k <= k_max) DO
+	WHILE active.size() > 0 AND (k_max == -1 OR k < k_max) DO
       deleted = SELECT v FROM active:v
           WHERE v.@deg <= k
           ACCUM v.@core += k;
@@ -36,7 +36,7 @@ CREATE QUERY kcore(STRING v_type, STRING e_type, INT k_min = 0, INT k_max = -1, 
               shells = Q MINUS active;
               PRINT k, shells; 
           END;
-          IF active.size() > 0 THEN
+          IF active.size() > 0THEN
               Q = active;
           END;
         

--- a/3.0.0/kcore.gsql
+++ b/3.0.0/kcore.gsql
@@ -1,0 +1,69 @@
+CREATE QUERY kcore(STRING v_type, STRING e_type, INT k_min = 0, INT k_max = -1, BOOL print_accum = TRUE, STRING attr = "", STRING file_path = "", BOOL show_membership = FALSE, BOOL show_shells=FALSE){ 
+/* An implementation of Algorithm 2 in
+ * Scalable K-Core Decomposition for Static Graphs Using a Dynamic Graph Data Structure,
+ * Tripathy et al., IEEE Big Data 2018.
+ 
+  This query supports only taking in a single edge for the time being (8/13/2020).
+ */
+	SumAccum<INT> @deg;        // The number of edges v has to active vertices.
+  SumAccum<INT> @core;       // The core level of vertex v
+  FILE f(file_path);
+  INT k;             			    
+	k = k_min;				      
+	
+	active = {v_type.*};
+	active = SELECT v                  // Initialize @deg
+	    FROM active:v
+	    POST-ACCUM v.@deg += v.outdegree(e_type);
+  
+  
+	Q = active;
+	WHILE active.size() > 0 AND (k_max == -1 OR k <= k_max) DO
+      deleted = SELECT v FROM active:v
+          WHERE v.@deg <= k
+          ACCUM v.@core += k;
+  
+      active = active MINUS deleted;
+  
+	    IF deleted.size() > 0 THEN                // "Remove adjacent edges"         
+	        U = SELECT u
+	            FROM deleted:u -(e_type:e)-> :v
+	            ACCUM  v.@deg += -1;  // Actually, reduce degree of vertices
+	    ELSE 
+  
+          // Show vertices which did not satisfy kcore condition at a value of k
+	        IF show_shells THEN 
+              shells = Q MINUS active;
+              PRINT k, shells; 
+          END;
+          IF active.size() > 0 THEN
+              Q = active;
+          END;
+        
+          //show all vertices which satisfied the condition at k.
+          IF show_membership THEN 
+            PRINT k, Q as members;
+          END;
+  
+          k = k + 1;
+	    END;
+  END;
+  
+  IF file_path != "" THEN
+    f.println("Vertex", "Core");
+  END;
+  
+  IF file_path != "" OR attr != "" THEN
+    Seed = {v_type.*};
+    Seed = SELECT s FROM Seed:s
+            POST-ACCUM
+              IF file_path != "" THEN f.println(s, s.@core) END,
+              IF attr != "" THEN s.setAttr(attr, s.@core) END;
+  
+  END;
+  
+  IF print_accum THEN
+    PRINT k, Q.size() as core_size, Q as max_core;
+  END;
+	
+}

--- a/3.0.0/knn_cosine_all.gsql
+++ b/3.0.0/knn_cosine_all.gsql
@@ -9,7 +9,10 @@ CREATE QUERY knn_cosine_all(SET<STRING> v_type, SET<STRING> e_type, SET<STRING> 
         source = SELECT s
                  FROM source:s 
                  WHERE s.getAttr(label, "STRING") == ""
-                  POST-ACCUM s.@predicted_label = knn_cosine_all_sub(s, e_type,re_type, weight, label,top_k),
+                  POST-ACCUM s.@predicted_label = knn_cosine_all_sub(s, e_type,re_type, weight, label,top_k);
+  
+        source = SELECT s FROM source:s
+                  POST-ACCUM
                   IF file_path != "" THEN f.println(s, s.@predicted_label) END,
                   IF attr != "" THEN s.setAttr(attr, s.@predicted_label) END;
       

--- a/3.0.0/knn_cosine_all.gsql
+++ b/3.0.0/knn_cosine_all.gsql
@@ -1,0 +1,19 @@
+CREATE QUERY knn_cosine_all(SET<STRING> v_type, SET<STRING> e_type, SET<STRING> re_type, STRING weight, STRING label, INT top_k, BOOL print_accum = TRUE, STRING file_path = "", STRING attr = ""){
+/* This query is k-nearest neighbors based on Cosine Similarity on all vertices.
+   The output is the predicted label for all the vertices depending on the majority label of their k-nearest neighbors.
+*/
+        SumAccum<STRING> @predicted_label;
+        FILE f (file_path);
+        
+        source = {v_type};        
+        source = SELECT s
+                 FROM source:s 
+                 WHERE s.getAttr(label, "STRING") == ""
+                  POST-ACCUM s.@predicted_label = knn_cosine_all_sub(s, e_type,re_type, weight, label,top_k),
+                  IF file_path != "" THEN f.println(s, s.@predicted_label) END,
+                  IF attr != "" THEN s.setAttr(attr, s.@predicted_label) END;
+      
+      IF print_accum THEN
+        PRINT source;
+      END;  
+}

--- a/3.0.0/knn_cosine_all_sub.gsql
+++ b/3.0.0/knn_cosine_all_sub.gsql
@@ -1,0 +1,44 @@
+CREATE QUERY knn_cosine_all_sub (VERTEX source, SET<STRING> e_type, SET<STRING> re_type, STRING weight, STRING label, INT top_k) RETURNS (STRING) {
+/* This subquery is k-nearest neighbors based on Cosine Similarity between a given vertex and every other vertex.
+Cosine similarity = A \dot B / ||A|| \dot ||B||
+*/
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
+        MapAccum<STRING, INT> @@count;
+        INT max_count = 0;
+        STRING predicted_label;
+
+        # calculate similarity and find the top k nearest neighbors
+        start = {source};
+        subjects = SELECT t
+                   FROM start:s -(e_type:e)-> :t
+                   ACCUM t.@numerator = e.getAttr(weight, "FLOAT"),
+                         @@norm1 += pow(e.getAttr(weight, "FLOAT"), 2);
+
+        neighbours = SELECT t
+                     FROM subjects:s -(re_type:e)-> :t
+                     WHERE t != source AND t.getAttr(label, "STRING") != ""    # only consider the ones with known label
+                     ACCUM t.@numerator += s.@numerator * e.getAttr(weight, "FLOAT");
+
+        kNN = SELECT s
+              FROM neighbours:s -(e_type:e)-> :t
+              ACCUM s.@norm2 += pow(e.getAttr(weight, "FLOAT"), 2)
+              POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+              ORDER BY s.@similarity DESC
+              LIMIT top_k;
+
+        #predict label
+        kNN = SELECT s
+              FROM kNN:s
+              ACCUM @@count += (s.getAttr(label, "STRING") -> 1);
+
+        FOREACH (pred_label, cnt) IN @@count DO
+            IF cnt > max_count THEN
+                max_count = cnt;
+                predicted_label = pred_label;
+            END;
+        END;
+
+        PRINT predicted_label;
+        RETURN predicted_label;
+
+}

--- a/3.0.0/knn_cosine_cv.gsql
+++ b/3.0.0/knn_cosine_cv.gsql
@@ -1,0 +1,54 @@
+CREATE QUERY knn_cosine_cv (SET<STRING> v_type, SET<STRING> e_type, SET<STRING> re_type, STRING weight, STRING label, INT min_k, INT max_k) RETURNS (INT){
+/* Leave-one-out cross validation for selecting optimal k. 
+   The input is a range of k, output is the k with highest correct prediction rate.
+   Note: When one vertex has no neighbor with known label, the prediction is considered false
+*/
+        ListAccum<FLOAT> @@correct_rate_list; 
+        ListAccum<INT> @is_correct_list; 
+        ListAccum<STRING> @predicted_label_list;
+        SumAccum<FLOAT> @@total_score;
+        INT n, k, best_k=1;
+        FLOAT max_rate=0;
+  
+        IF max_k < min_k OR max_k < 1 THEN  // terminate if the range is invalid
+                RETURN 0;
+        END;
+        start = {v_type};
+  
+        start = SELECT s
+                FROM start:s 
+                WHERE s.getAttr(label, "STRING") != ""  // get the vertices with known label
+                ACCUM s.@predicted_label_list = knn_cosine_cv_sub(s, e_type, re_type, label, weight, max_k)  // get a list of predicted label wrt different k
+                POST-ACCUM FOREACH pred_label IN s.@predicted_label_list DO
+                                   IF s.getAttr(label, "STRING") == pred_label THEN  # *vStrAttrOld*  means no neighbor with label
+                                           s.@is_correct_list += 1
+                                   ELSE
+                                           s.@is_correct_list += 0
+                                   END                   
+                           END;
+  
+	n = start.size();
+        k = min_k-1;  # index starts from 0
+        WHILE k < max_k DO
+                @@total_score = 0;
+                start = SELECT s
+                        FROM start:s 
+                        ACCUM IF s.@is_correct_list.size()==0 THEN
+                                      @@total_score += 0  # if there is no neighbor, it is considered incorrect prediction
+                              ELSE IF k >= s.@is_correct_list.size() THEN
+                                      @@total_score += s.@is_correct_list.get(s.@is_correct_list.size()-1)   # use all neighbors it has when it is not enough  
+                              ELSE 
+                                      @@total_score += s.@is_correct_list.get(k)
+                              END;
+                @@correct_rate_list += @@total_score / n;
+                IF @@total_score / n > max_rate THEN
+                        max_rate = @@total_score / n;  # store the max correct rate in max_rate
+                        best_k = k+1;
+                END;
+                k = k+1;
+        END;
+
+        PRINT @@correct_rate_list;
+        PRINT best_k;
+        RETURN best_k;
+}

--- a/3.0.0/knn_cosine_cv_sub.gsql
+++ b/3.0.0/knn_cosine_cv_sub.gsql
@@ -1,0 +1,44 @@
+CREATE QUERY knn_cosine_cv_sub (VERTEX source, SET<STRING> e_type, SET<STRING> re_type, STRING v_label, STRING weight, INT max_k) RETURNS (ListAccum<STRING>) {
+/* This subquery returns a list of predicted label for a source vertex with respect to different k within a given range. 
+*/ 
+        TYPEDEF TUPLE <label STRING, similarity FLOAT> Label_Score;
+        HeapAccum<Label_Score>(max_k, similarity DESC) @@top_labels_heap;  # heap stores the (label, similarity) tuple, order by similarity score
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
+        MapAccum<STRING, INT> @@count;
+        ListAccum<STRING> @@predicted_label_lists;  # list of predicted labels to return
+        INT max_count = 0;
+        STRING predicted_label;   # predicted label in each iteration
+        INT k;
+
+        # calculate similarity and find the top k nearest neighbors
+        start = {source};
+        subjects = SELECT t
+                   FROM start:s -(e_type:e)-> :t
+                   ACCUM t.@numerator = e.getAttr(weight, "FLOAT"),
+                         @@norm1 += pow(e.getAttr(weight, "FLOAT"), 2);
+
+        neighbours = SELECT t
+                     FROM subjects:s -(re_type:e)-> :t
+                     WHERE t != source AND t.getAttr(v_label, "STRING") != ""    # only consider the neighbors with known label
+                     ACCUM t.@numerator += s.@numerator * e.getAttr(weight, "FLOAT");
+
+        kNN = SELECT s
+              FROM neighbours:s -(e_type:e)-> :t
+              ACCUM s.@norm2 += pow(e.getAttr(weight, "FLOAT"), 2)
+              POST-ACCUM @@top_labels_heap += Label_Score(s.getAttr(v_label, "STRING"), s.@numerator/sqrt(@@norm1 * s.@norm2)); # store the label and similarity score in a heap 
+
+	# iterate the heap and calculate label count for different k
+        k = 1;
+        FOREACH item IN @@top_labels_heap DO  
+                @@count += (item.label -> 1);   # count is a map, key is the label, value is the count of the label
+                IF @@count.get(item.label) > max_count THEN
+                         max_count = @@count.get(item.label);
+                         predicted_label = item.label;
+                END;
+		@@predicted_label_lists += predicted_label;  # list of predicted labels
+                k = k+1;
+        END;
+      
+        PRINT @@predicted_label_lists;
+        RETURN @@predicted_label_lists;
+}

--- a/3.0.0/knn_cosine_ss.gsql
+++ b/3.0.0/knn_cosine_ss.gsql
@@ -1,0 +1,55 @@
+CREATE QUERY knn_cosine_ss (VERTEX source, SET<STRING> v_type, SET<STRING> e_type, SET<STRING> re_type, STRING weight, STRING label, INT top_k, BOOL print_accum = TRUE, STRING file_path = "", STRING attr = "") RETURNS (STRING) {
+
+/* This query is k-nearest neighbors based on Cosine Similarity between a given vertex and every other vertex.
+Cosine similarity = A \dot B / ||A|| \dot ||B||
+The output is the predicted label for the source vertex, which is the majority label of its k-nearest neighbors. 
+*/
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
+        MapAccum<STRING, INT> @@labels_count_map;
+        FILE f(file_path);
+        INT max_count = 0;
+        STRING predicted_label;
+        # calculate similarity and find the top k nearest neighbors
+        start = {source};
+        subjects = SELECT t
+                   FROM start:s -(e_type:e)-> :t
+                   ACCUM t.@numerator = e.getAttr(weight, "FLOAT"),
+                         @@norm1 += pow(e.getAttr(weight, "FLOAT"), 2);
+        neighbours = SELECT t
+                     FROM subjects:s -(re_type:e)-> :t
+                     WHERE t != source AND t.getAttr(label, "STRING") != ""    # only consider the neighbours with known label
+                     ACCUM t.@numerator += s.@numerator * e.getAttr(weight, "FLOAT");
+        kNN = SELECT s
+              FROM neighbours:s -(e_type:e)-> :t
+              ACCUM s.@norm2 += pow(e.getAttr(weight, "FLOAT"), 2)
+              POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+              ORDER BY s.@similarity DESC
+              LIMIT top_k; 
+        #predict label
+        kNN = SELECT s
+              FROM kNN:s
+              ACCUM @@labels_count_map += (s.getAttr(label, "STRING") -> 1);
+        
+        FOREACH (pred_label, cnt) IN @@labels_count_map DO
+            IF cnt > max_count THEN
+                max_count = cnt;
+                predicted_label = pred_label;
+            END;
+        END;
+  
+        IF attr != "" THEN
+          start = SELECT s
+                  FROM start:s
+                  POST-ACCUM s.setAttr(attr, predicted_label);
+        END;
+        
+        IF print_accum THEN
+          PRINT predicted_label;
+        END;
+  
+        IF file_path != ""  THEN
+          f.println(source, predicted_label);
+        END;
+ 
+        RETURN predicted_label;
+}

--- a/3.0.0/label_prop.gsql
+++ b/3.0.0/label_prop.gsql
@@ -1,0 +1,53 @@
+CREATE QUERY label_prop (SET<STRING> v_type, SET<STRING> e_type, INT max_iter, INT output_limit, BOOL print_accum = TRUE, STRING file_path = "", STRING attr = ""){
+# Partition the vertices into communities, according to the Label Propagation method.
+# Indicate community membership by assigning each vertex a community ID.
+
+        OrAccum @@changed = true;
+        MapAccum<INT, INT> @map;     # <communityId, numNeighbors>
+        MapAccum<INT, INT> @@commSizes;   # <communityId, members>
+        SumAccum<INT> @label, @num;  
+        FILE f (file_path);
+        Start = {v_type};
+
+# Assign unique labels to each vertex
+        Start = SELECT s FROM Start:s ACCUM s.@label = getvid(s);
+
+# Propagate labels to neighbors until labels converge or the max iterations is reached
+        WHILE @@changed == true LIMIT max_iter DO
+                @@changed = false;
+                Start = SELECT s 
+                        FROM Start:s -(e_type:e)-> :t
+                        ACCUM t.@map += (s.@label -> 1)  # count the occurrences of neighbor's labels
+                        POST-ACCUM
+                                INT maxV = 0,
+                                INT label = 0,
+                                # Iterate over the map to get the neighbor label that occurs most often
+                                FOREACH (k,v) IN t.@map DO
+                                        CASE WHEN v > maxV THEN
+                                                maxV = v,
+                                                label = k
+                                        END
+                                END,
+                                # When the neighbor search finds a label AND it is a new label
+                                # AND the label's count has increased, update the label.
+                                CASE WHEN label != 0 AND t.@label != label AND maxV > t.@num THEN
+                                        @@changed += true,
+                                        t.@label = label,
+                                        t.@num = maxV
+                                END,
+                                t.@map.clear();
+        END;
+
+        Start = {v_type};
+        Start =  SELECT s FROM Start:s
+                  POST-ACCUM 
+                        IF attr != "" THEN s.setAttr(attr, s.@label) END,
+                        IF file_path != "" THEN f.println(s, s.@label) END,
+                        IF print_accum THEN @@commSizes += (s.@label -> 1) END
+                  LIMIT output_limit;
+
+        IF print_accum THEN 
+           PRINT @@commSizes;
+           PRINT Start[Start.@label];
+        END;
+}

--- a/3.0.0/max_BFS_depth.gsql
+++ b/3.0.0/max_BFS_depth.gsql
@@ -1,0 +1,13 @@
+CREATE QUERY max_BFS_depth(VERTEX source, SET<STRING> e_type) RETURNS (INT){ 
+	OrAccum @visited;
+	INT depth=-1;
+  start = {source};
+	WHILE start.size() > 0 DO
+	  depth = depth + 1;
+	  start = SELECT t
+	          FROM start:s -(e_type:e) ->:t 
+	          WHERE NOT t.@visited
+	          ACCUM t.@visited = TRUE;
+	END;
+	RETURN depth;
+}

--- a/3.0.0/maximal_indep_set.gsql
+++ b/3.0.0/maximal_indep_set.gsql
@@ -1,0 +1,59 @@
+CREATE QUERY maximal_indep_set(STRING v_type, STRING e_type, INT max_iter = 100, BOOL print_accum = TRUE, STRING file_path = ""){ 
+    /*
+    Maximal Independent Set query only supports one edge type and works only for undirected graphs at the moment (8/12/20).
+    */
+  
+    AndAccum @active;
+    OrAccum @selected;
+    MinAccum<INT> @vid_min;
+    FILE f(file_path);
+    INT iter = 0;
+  
+    Start = {v_type.*};
+    Start = SELECT s FROM Start:s
+                ACCUM
+                  IF s.outdegree(e_type) == 0 THEN
+                     s.@selected += TRUE,
+                     s.@active += FALSE
+                  END
+                 HAVING s.@active;
+    
+    WHILE Start.size()>0 AND iter<max_iter DO
+        Start = SELECT s FROM Start:s
+                POST-ACCUM
+                  s.@vid_min = 9223372036854775807;
+    
+        TMP = SELECT s FROM Start:s-(e_type:e)->v_type:t
+              WHERE t.@active
+                ACCUM
+                   s.@vid_min += getvid(t);
+    
+        TMP = SELECT s FROM Start:s
+                        POST-ACCUM
+                             IF getvid(s) < s.@vid_min THEN
+                                    s.@selected += TRUE,
+                                    s.@active += FALSE
+                             END
+                        HAVING s.@selected;
+    
+        TMP = SELECT s FROM TMP:s-(e_type:e)->v_type:t
+              ACCUM
+                   t.@active += FALSE;
+    
+        Start = SELECT s FROM Start:s WHERE s.@active;
+        iter = iter+1;   
+    END;
+  
+    IF file_path != "" THEN
+      f.println("Vertex");
+    END;
+  
+    Start = {v_type.*};
+    Start = SELECT s FROM Start:s 
+            WHERE s.@selected
+            ACCUM IF file_path != "" THEN f.println(s) END;
+  
+    IF print_accum THEN
+      PRINT Start;
+    END;
+}

--- a/3.0.0/msf.gsql
+++ b/3.0.0/msf.gsql
@@ -1,0 +1,139 @@
+CREATE QUERY msf (SET<STRING> v_type, SET<STRING> e_type, STRING weight, BOOL print_accum = TRUE, STRING boolean_attr = "", STRING file_path = ""){
+/*
+ * This query identifies minimum spanning trees using the algorithm in section 6.2 of Qin et al. 2014:
+ * http://www-std1.se.cuhk.edu.hk/~hcheng/paper/SIGMOD2014qin.pdf.
+ */
+        TYPEDEF TUPLE <FLOAT weight, VERTEX from_v, VERTEX to_v, EDGE e, INT vid> EDGE_WEIGHT;
+        MapAccum<VERTEX, VERTEX> @@parents_map;
+        MapAccum<VERTEX, AndAccum<BOOL>> @@star_map;
+
+        SumAccum<INT> @@parent_changed_count;
+        SetAccum<EDGE> @@result;
+        SetAccum<EDGE_WEIGHT> @@mst;
+        
+        HeapAccum<EDGE_WEIGHT>(1, weight ASC, to_v ASC, vid ASC) @ew_heap;
+        MinAccum<VERTEX> @parent; # Given a vertex v, we need to be able to send its outgoing edge info to its parent, which is only posible if we store the parent in a local accumulator.
+        OrAccum @ignore;
+        FILE f (file_path);
+
+        all_v = {v_type};
+
+        ### FOREST INITIALIZATION ###
+        # For each node v, let parent p(v) = neighbor of v connected via the least-weighted edge.
+        all_v = SELECT v FROM all_v:v -(e_type:e)-> :u
+                ACCUM
+                    v.@ew_heap += EDGE_WEIGHT(e.getAttr(weight, "FLOAT"), v,u,e, getvid(u))
+                POST-ACCUM
+                    @@parents_map += (v -> v.@ew_heap.top().to_v),
+                    @@parent_changed_count += 1
+            ;
+
+        WHILE @@parent_changed_count > 0 DO
+            ### BREAK CYCLES ###
+            all_v = SELECT v
+                    FROM all_v:v
+                    POST-ACCUM v.@ignore = false;
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        VERTEX p = @@parents_map.get(v),
+                        VERTEX gp = @@parents_map.get(p),
+                        IF v != p AND v == gp THEN
+                            IF (getvid(v) < getvid(p)) THEN
+                                @@parents_map += (v -> v),
+                                v.@ignore = TRUE
+                            END
+                        END
+                    ;
+
+            # only add edges to MST after breaking cycles to avoid double counting edges
+            add_edges = SELECT v FROM all_v:v WHERE v.@ignore == false AND v.@ew_heap.size() > 0
+                        POST-ACCUM
+                          IF file_path != "" THEN @@mst += v.@ew_heap.top() END,
+                          IF print_accum OR boolean_attr != "" THEN @@result += v.@ew_heap.top().e END;
+
+            ### UPDATE PARENT POINTERS ###
+            @@parent_changed_count = 0;
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        VERTEX p = @@parents_map.get(v),
+                        VERTEX gp = @@parents_map.get(p),
+                        IF (p != gp) THEN
+                            @@parent_changed_count += 1,
+                            @@parents_map += (v -> gp)
+                        END
+                    ;
+            IF @@parent_changed_count == 0 THEN
+                BREAK;
+            END;
+
+            ### STAR DETECTION ###
+            @@star_map.clear();
+            # Rule 1: Let s(v) = 1 if p(v) = p(p(v))
+            # Only root and depth 1 vertices will have s(v) = 1. Everything else will have s(v) = 0.
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        VERTEX parent = @@parents_map.get(v),
+                        IF parent == @@parents_map.get(parent) THEN
+                            @@star_map += (v -> true)
+                        ELSE
+                            @@star_map += (v -> false)
+                        END
+                    ;
+
+            # Rule 2: If s(v) = 1 but v has a grandchild u such that s(u) = 0, then s(v) = 0. This will end up updating root vertices. 
+            not_star_roots =    SELECT u FROM all_v:u
+                                WHERE
+                                    @@star_map.get(u) == false
+                                POST-ACCUM
+                                    @@star_map += (@@parents_map.get(@@parents_map.get(u)) -> false)
+                                ;
+
+            # Rule 3: If s(p(v)) = 0, then s(v) = 0. This will end up updating vertices at depth 1 of trees.
+            not_star_depth1 =   SELECT u FROM all_v:u
+                                WHERE
+                                    @@star_map.get(@@parents_map.get(u)) == false
+                                POST-ACCUM
+                                    @@star_map += (u -> false)
+                                ;
+
+            ### STAR HOOKING ###
+            # First, we need to clear each vertex's heap and reset the local @parent.
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        v.@ew_heap.clear(),
+                        v.@parent = @@parents_map.get(v)
+                    ;
+            star_nodes =    SELECT v FROM all_v:v -(e_type:e)-> :u
+                            WHERE @@star_map.get(v) == true AND v.@parent != u.@parent
+                            ACCUM
+                                VERTEX parent = v.@parent,
+                                parent.@ew_heap += EDGE_WEIGHT(e.getAttr(weight, "FLOAT"), v,u,e, getvid(u));
+            updated_star_roots =    SELECT v FROM all_v:v
+                                    WHERE
+                                        @@star_map.get(v) == true AND @@parents_map.get(v) == v AND v.@ew_heap.size() > 0
+                                    POST-ACCUM
+                                        @@parents_map += (v -> @@parents_map.get(v.@ew_heap.top().to_v))
+                                    ;
+        END;
+        
+        IF boolean_attr != "" THEN
+          all_v = SELECT v FROM all_v:v -(e_type:e)-> :u
+                ACCUM
+                IF e IN @@result THEN
+                  e.setAttr(boolean_attr, TRUE)
+                  ELSE
+                  e.setAttr(boolean_attr, FALSE)
+                 END;
+        END;
+  
+        IF print_accum THEN
+          PRINT @@result;
+        END;
+        
+        IF file_path != "" THEN
+          f.println("From", "To", "Weight");
+          FOREACH e IN @@mst DO
+              f.println(e.from_v, e.to_v, e.weight);
+      END;
+        END;
+}

--- a/3.0.0/mst.gsql
+++ b/3.0.0/mst.gsql
@@ -1,0 +1,55 @@
+CREATE QUERY mst(SET<STRING> v_type, SET<STRING> e_type, STRING weight, BOOL print_accum = TRUE, STRING file_path = "", STRING boolean_attr = ""){ 
+  TYPEDEF TUPLE<VERTEX from_v, VERTEX to_v, EDGE e, FLOAT weight, INT vid> EDGE_WEIGHT;
+  HeapAccum<EDGE_WEIGHT>(1, weight ASC, vid ASC) @@chosen_edge; //only need to keep the minimal tuple
+  SetAccum<EDGE_WEIGHT> @@mst;
+  SetAccum<EDGE> @@result;
+  OrAccum @chosen;
+  FILE f (file_path);
+        
+        all_v = {v_type};
+        
+        MSTNodes = SELECT s FROM all_v:s LIMIT 1;
+        // initialize the source vertex
+        Current = SELECT s FROM MSTNodes:s
+                  ACCUM s.@chosen = true;
+
+        WHILE (Current.size() > 0) DO
+                Current = SELECT t
+                          FROM MSTNodes:s -(e_type:e) -> :t
+                          WHERE t.@chosen == false    // vertex not in MSTNodes
+                          ACCUM @@chosen_edge += EDGE_WEIGHT(s, t, e, e.getAttr(weight, "FLOAT"), getvid(t))
+                          POST-ACCUM IF t == @@chosen_edge.top().to_v THEN    
+                                              t.@chosen = TRUE      // mark the chosen vertex to add into MSTNodes
+                                     END
+                          HAVING t.@chosen == true;
+  
+                IF @@chosen_edge.size() > 0 THEN
+                    IF boolean_attr != "" THEN
+                      S = SELECT s
+                           FROM Current:s -(e_type:e) -> :t
+                           WHERE t == @@chosen_edge.top().from_v
+                           ACCUM e.setAttr(boolean_attr, TRUE);
+  
+                    END;
+                    IF file_path != "" THEN
+                       @@mst += @@chosen_edge.top();
+                    END;
+                    IF print_accum THEN
+                      @@result += @@chosen_edge.top().e;
+                    END;
+                END;    
+                @@chosen_edge.clear();
+                MSTNodes = MSTNodes UNION Current;      // update MSTNodes
+        END;
+  
+      IF print_accum THEN
+        PRINT @@result as mst;
+      END;
+      
+      IF file_path != "" THEN
+         f.println("From", "To", "Weight");
+          FOREACH e in @@mst DO
+            f.println(e.from_v, e.to_v, e.weight);
+          END;
+      END;
+}

--- a/3.0.0/pageRank.gsql
+++ b/3.0.0/pageRank.gsql
@@ -28,6 +28,10 @@ CREATE QUERY pageRank (STRING v_type, STRING e_type, INT output_limit, FLOAT max
                                @@maxDiff += abs(s.@score - s.@score');
         END; # END WHILE loop
         
+        IF file_path != "" THEN
+          f.println("Vertex_ID", "PageRank");
+        END;
+  
         V = SELECT s FROM Start:s
             POST-ACCUM 
                 IF attr != "" THEN s.setAttr(attr, s.@score) END,

--- a/3.0.0/pageRank.gsql
+++ b/3.0.0/pageRank.gsql
@@ -1,0 +1,49 @@
+CREATE QUERY pageRank (STRING v_type, STRING e_type, INT output_limit, FLOAT max_change=0.001, INT max_iter=25, FLOAT damping=0.85, STRING attr =  "", STRING file_path = "", BOOL print_accum = TRUE, BOOL display = FALSE){
+# Compute the pageRank score for each vertex in the GRAPH
+# In each iteration, compute a score for each vertex:
+#   score = (1-damping) + damping*sum(received scores FROM its neighbors).
+# The pageRank algorithm stops when either of the following is true:
+#  a) it reaches max_iter iterations;
+#  b) the max score change for any vertex compared to the last iteration <= max_change.
+  
+  /*
+   This query supports only taking in a single edge for the time being (8/13/2020).
+  */
+
+        TYPEDEF TUPLE<VERTEX Vertex_ID, FLOAT score> Vertex_Score;
+         HeapAccum<Vertex_Score>(output_limit, score DESC) @@topScores;
+        MaxAccum<FLOAT> @@maxDiff = 9999; # max score change in an iteration
+        SumAccum<FLOAT> @received_score = 0; # sum of scores each vertex receives FROM neighbors
+        SumAccum<FLOAT> @score = 1;   # Initial score for every vertex is 1.
+        SetAccum<EDGE> @@edgeSet;                   # list of all edges, if display is needed
+        FILE f (file_path);
+        Start = {v_type};   #  Start with all vertices of specified type(s)
+        WHILE @@maxDiff > max_change LIMIT max_iter DO
+                @@maxDiff = 0;
+                V = SELECT s
+                    FROM Start:s -(e_type:e)-> :t
+                    ACCUM t.@received_score += s.@score/(s.outdegree(e_type)) 
+                    POST-ACCUM s.@score = (1.0-damping) + damping * s.@received_score,
+                               s.@received_score = 0,
+                               @@maxDiff += abs(s.@score - s.@score');
+        END; # END WHILE loop
+        
+        V = SELECT s FROM Start:s
+            POST-ACCUM 
+                IF attr != "" THEN s.setAttr(attr, s.@score) END,
+                IF file_path != "" THEN f.println(s, s.@score) END,
+                IF print_accum THEN @@topScores += Vertex_Score(s, s.@score) END;
+    
+  
+        IF print_accum AND output_limit > 0 THEN
+               PRINT @@topScores AS top_scores;
+        END;
+
+        IF print_accum AND display THEN
+                PRINT Start[Start.@score];
+                Start = SELECT s
+                        FROM Start:s -(e_type:e)-> :t
+                        ACCUM @@edgeSet += e;
+               PRINT @@edgeSet;
+        END;
+}

--- a/3.0.0/pageRank_pers.gsql
+++ b/3.0.0/pageRank_pers.gsql
@@ -1,0 +1,60 @@
+CREATE QUERY pageRank_pers(SET<VERTEX> source, STRING e_type, INT output_limit, FLOAT max_change=0.001, INT max_iter=25, FLOAT damping = 0.85, STRING attr = "", STRING file_path = "", BOOL print_accum = TRUE){
+# Compute the pageRank score for each vertex in the GRAPH, given a set of source vertices
+# In each iteration, compute a score for activated vertices if they are source vertices:
+#   score = (1-damping) + damping*sum(received scores FROM its neighbors).
+# If they are not source vertices, then score = damping*sum(received scores FROM its neighbors).
+# The personalized pageRank algorithm stops when either of the following is true:
+#  a) it reaches max_iter iterations;
+#  b) the max score change for any vertex compared to the last iteration <= maxChange.
+  
+# pageRank_pers only supports a single edge at the moment (8/13/2020).
+
+  TYPEDEF TUPLE<VERTEX vertex_id, FLOAT score> Vertex_Score;
+  HeapAccum<Vertex_Score>(output_limit, score DESC) @@topScores;
+  MaxAccum<FLOAT> @@maxDiff = 9999; # max score change in an iteration
+  SumAccum<FLOAT> @received_score = 0; # sum of scores each vertex receives FROM neighbors
+  SumAccum<FLOAT> @score = 0;   # Initial score for every vertex is 0
+  SetAccum<EDGE> @@edgeSet;                   # list of all edges, if display is needed
+  OrAccum @is_source;  
+  FILE f (file_path);
+  
+        IF file_path != "" THEN
+          f.println("Vertex_ID", "PageRank");
+        END;
+       
+        Start = {source};   #  Start with a set of vertices
+        Start = SELECT s
+                FROM  Start:s
+                ACCUM s.@score = 1,   # Only set score of source vertices to 1
+                      s.@is_source = true;
+        Total = Start;
+        WHILE @@maxDiff > max_change LIMIT max_iter DO
+              @@maxDiff = 0;
+              V_tmp = SELECT t      # Only update score for activated vertices
+                      FROM Start:s -(e_type:e)-> :t
+                      ACCUM t.@received_score += s.@score/(s.outdegree(e_type));
+              T = Start UNION V_tmp;
+              Start = SELECT s
+                      FROM T:s
+                      POST-ACCUM
+                          # For source vertices, if it's activated, then add damping; if not activated, do not need to update
+                          IF s.@is_source == true
+                          THEN s.@score = (1.0-damping) + damping * s.@received_score
+                          ELSE s.@score = damping * s.@received_score
+                          END,
+                          s.@received_score = 0,
+                          @@maxDiff += abs(s.@score - s.@score');
+              Total = Total UNION T; 
+        END; # END WHILE loop
+        
+      Total = Select s From Total:s
+              POST-ACCUM 
+                          IF attr != "" THEN s.setAttr(attr, s.@score) END,
+                          IF file_path != "" THEN f.println(s, s.@score) END,
+                          IF print_accum THEN @@topScores += Vertex_Score(s, s.@score) END
+              LIMIT output_limit;
+                
+        IF print_accum THEN
+            PRINT @@topScores as top_scores;
+        END;
+}

--- a/3.0.0/pageRank_wt.gsql
+++ b/3.0.0/pageRank_wt.gsql
@@ -32,11 +32,15 @@ Start = SELECT s
                                @@maxDiff += abs(s.@score - s.@score');
         END;
 
+        IF file_path != "" THEN
+          f.println("Vertex_ID", "PageRank");
+        END;
+  
         V = SELECT s FROM Start:s
             POST-ACCUM 
                         IF attr != "" THEN s.setAttr(attr, s.@score) END,
                         IF print_accum THEN @@topScores += Vertex_Score(s, s.@score) END,
-                        IF file_path != "" THEN f.println("Vertex_ID", "PageRank") END
+                        IF file_path != "" THEN f.println(s, s.@score) END
             LIMIT output_limit;
 
        IF print_accum THEN

--- a/3.0.0/pageRank_wt.gsql
+++ b/3.0.0/pageRank_wt.gsql
@@ -1,0 +1,54 @@
+CREATE QUERY pageRank_wt (SET<STRING> v_type, SET<STRING> e_type, STRING weight, INT output_limit, FLOAT max_change=0.001, INT max_iter=25, FLOAT damping=0.85, BOOL print_accum = TRUE, STRING file_path="", STRING attr="", BOOL display = FALSE){
+# Compute the pageRank score for each vertex in the GRAPH, using weighted edge.
+# In each iteration, compute a score for each vertex:
+#   score = (1-damping) + damping*sum(received scores FROM its neighbors).
+# The pageRank algorithm stops when either of the following is true:
+#  a) it reaches max_iter iterations;
+#  b) the max score change for any vertex compared to the last iteration <= max_change.
+
+TYPEDEF TUPLE<VERTEX Vertex_ID, FLOAT score> Vertex_Score;
+HeapAccum<Vertex_Score>(output_limit, score DESC) @@topScores;
+MaxAccum<FLOAT> @@maxDiff = 9999; # max score change in an iteration
+SumAccum<FLOAT> @received_score = 0; # sum of scores each vertex receives FROM neighbors
+SumAccum<FLOAT> @score = 1;   # Initial score for every vertex is 1.
+SetAccum<EDGE> @@edgeSet;                   # list of all edges, if display is needed
+SumAccum<FLOAT> @total_weight;
+FILE f (file_path);
+  
+Start = {v_type};   #  Start with all vertices of specified type(s)
+        
+        
+Start = SELECT s                
+            FROM Start:s -(e_type:e) -> :t
+            ACCUM s.@total_weight += e.getAttr(weight, "FLOAT");  # Calculate the total weight for each vertex
+
+        WHILE @@maxDiff > max_change LIMIT max_iter DO
+                @@maxDiff = 0;
+                V = SELECT s
+                    FROM Start:s -(e_type:e)-> :t
+                    ACCUM t.@received_score += s.@score * e.getAttr(weight, "FLOAT") / s.@total_weight
+                    POST-ACCUM s.@score = (1.0-damping) + damping * s.@received_score,
+                               s.@received_score = 0,
+                               @@maxDiff += abs(s.@score - s.@score');
+        END;
+
+        V = SELECT s FROM Start:s
+            POST-ACCUM 
+                        IF attr != "" THEN s.setAttr(attr, s.@score) END,
+                        IF print_accum THEN @@topScores += Vertex_Score(s, s.@score) END,
+                        IF file_path != "" THEN f.println("Vertex_ID", "PageRank") END
+            LIMIT output_limit;
+
+       IF print_accum THEN
+            PRINT @@topScores as top_scores;
+       END;
+
+
+      IF display THEN
+        PRINT Start[Start.@score];
+        Start = SELECT s
+        FROM Start:s -(e_type:e)-> :t
+                ACCUM @@edgeSet += e;
+        PRINT @@edgeSet as edge_set;
+    END;
+}

--- a/3.0.0/scc.gsql
+++ b/3.0.0/scc.gsql
@@ -1,0 +1,178 @@
+CREATE QUERY scc (SET<STRING> v_type, SET<STRING> e_type, SET<STRING> re_type, INT top_k_dist, INT output_limit, INT iter = 500, INT iter_wcc = 5, BOOL print_accum = TRUE, STRING attr= "", STRING file_path=""){ //INT iter_end_trim = 3
+/* This query detects strongly connected components based on the following papers:
+ * https://www.sandia.gov/~apinar/papers/irreg00.pdf
+ * https://www.sciencedirect.com/science/article/pii/S0743731505000535
+ * https://stanford-ppl.github.io/website/papers/sc13-hong.pdf
+
+ * iter: number of iteration of the algorithm
+ * iter_wcc: find weakly connected components for the active vertices in this iteration, since the largest sccs are already found after several iterations; usually a small number(3 to 10)
+ * top_k_dist: top k result in scc distribution
+
+ * DISTRIBUTED QUERY mode for this query is supported from TG 2.4.
+ */
+        TYPEDEF TUPLE <INT csize, INT num> cluster_num;
+        MapAccum<INT, INT> @@cluster_size_map, @@cluster_dist_map;
+        HeapAccum<cluster_num>(top_k_dist, csize DESC) @@cluster_dist_heap;
+        OrAccum @is_forward, @is_backward, @detached, @has_pos_indegree, @has_pos_outdegree, @wcc_active;
+        SumAccum<INT> @cid, @vid;
+        MinAccum<INT> @@min_vid, @wcc_id_curr, @wcc_id_prev;
+        SumAccum<STRING> @flag;
+        MapAccum<INT, MinAccum<INT>> @@f_cid_map, @@b_cid_map, @@n_cid_map, @@s_cid_map;
+        FILE f (file_path);
+        INT i = 1;
+        v_all = {v_type};
+  	tmp(ANY) ={};
+
+        active = SELECT s
+                FROM v_all:s
+                ACCUM s.@vid = getvid(s),
+                      @@min_vid += getvid(s)
+                POST-ACCUM s.@cid = @@min_vid;
+  
+        WHILE active.size()>0 LIMIT iter DO
+            
+                WHILE TRUE DO   
+                        tmp =  SELECT s
+                               FROM active:s -(e_type:e) -> :t
+                               WHERE t.@detached == FALSE AND s.@cid == t.@cid
+                               ACCUM s.@has_pos_outdegree = TRUE;
+  
+                        tmp =  SELECT s
+                               FROM active:s -(re_type:e) -> :t
+                               WHERE t.@detached == FALSE AND s.@cid == t.@cid
+                               ACCUM s.@has_pos_indegree = TRUE;
+                        trim_set = SELECT s
+                               FROM active:s
+                               WHERE s.@has_pos_indegree == FALSE OR s.@has_pos_outdegree == FALSE
+                               ACCUM s.@detached = TRUE,
+                                     s.@cid = s.@vid;
+                
+
+                        IF trim_set.size() == 0 THEN  // no single SCC anymore, terminate the while loop
+                                BREAK;
+                        END;
+                        active = SELECT s
+                                 FROM active:s 
+                                 WHERE s.@detached == FALSE
+                                 ACCUM @@n_cid_map += (s.@cid -> s.@vid)
+                                 POST-ACCUM s.@cid = @@n_cid_map.get(s.@cid),
+                                            s.@has_pos_indegree = FALSE,
+                                            s.@has_pos_outdegree = FALSE; 
+                        @@n_cid_map.clear();
+                END;
+                //END;
+                // get WCC
+                IF i == iter_wcc THEN
+                        active = SELECT s
+                                 FROM active:s
+                                 POST-ACCUM s.@wcc_id_curr = s.@vid,
+                                            s.@wcc_id_prev = s.@vid;
+                        curr = active;
+                        WHILE (curr.size()>0) DO
+                                curr = SELECT t
+                                       FROM curr:s -((e_type|re_type):e)-> :t
+                                       WHERE s.@cid == t.@cid AND t.@detached == FALSE
+                                       ACCUM t.@wcc_id_curr += s.@wcc_id_prev // If s has a smaller id than t, copy the id to t
+                                       POST-ACCUM
+                                                CASE WHEN t.@wcc_id_prev != t.@wcc_id_curr THEN // If t's id has changed
+                                                          t.@wcc_id_prev = t.@wcc_id_curr,
+                                                          t.@wcc_active = true
+                                                ELSE 
+                                                          t.@wcc_active = false
+                                                END
+                                        HAVING t.@wcc_active == true;       
+                        END;
+                        active = SELECT s
+                                 FROM active:s
+                                 ACCUM s.@cid = s.@wcc_id_curr;
+                END;
+                i = i + 1;
+  
+                pivots = SELECT s
+                         FROM active:s 
+                         WHERE s.@cid == s.@vid
+                         ACCUM s.@is_forward = TRUE,
+                               s.@is_backward = TRUE;
+          
+                // mark forward set
+                curr = pivots;
+                WHILE curr.size()>0 DO
+                        curr = SELECT t 
+                               FROM curr:s -(e_type:e)->:t  // edge
+                               WHERE t.@detached == FALSE AND t.@is_forward == FALSE AND s.@cid == t.@cid // not traversed
+                               ACCUM t.@is_forward = TRUE;
+                END;
+          
+                // mark backward set
+                curr = pivots;
+                WHILE curr.size()>0 DO
+                        curr = SELECT t 
+                               FROM curr:s -(re_type:e)->:t  // reverse edge
+                               WHERE t.@detached == FALSE AND t.@is_backward == FALSE AND s.@cid == t.@cid // not traversed
+                               ACCUM t.@is_backward = TRUE;
+                END;
+          
+                active = SELECT s
+                         FROM active:s 
+                         ACCUM IF s.@is_forward == TRUE AND s.@is_backward == TRUE THEN  // scc
+                                       s.@detached = TRUE,
+                                       @@s_cid_map += (s.@cid -> s.@vid)
+                               ELSE IF s.@is_forward == TRUE THEN  // forward set   
+			               @@f_cid_map += (s.@cid -> s.@vid)
+			       ELSE IF s.@is_backward == TRUE THEN    // backward set
+				       @@b_cid_map += (s.@cid -> s.@vid)
+			       ELSE 
+			               @@n_cid_map += (s.@cid -> s.@vid)   // null set
+		               END	
+                          POST-ACCUM IF s.@is_forward == TRUE AND s.@is_backward == TRUE THEN  // scc
+                                             s.@cid = @@s_cid_map.get(s.@cid)
+                                     END,
+                                     IF s.@is_forward == TRUE THEN
+                                             IF s.@is_backward == FALSE THEN   // forward set
+                                                     s.@cid = @@f_cid_map.get(s.@cid)
+                                             END
+                                     ELSE
+                                             IF s.@is_backward == TRUE THEN    // backward set
+                                                     s.@cid = @@b_cid_map.get(s.@cid) 
+                                             ELSE                              // null set
+                                                     s.@cid = @@n_cid_map.get(s.@cid) 
+                                             END
+                                     END,
+                                     s.@is_forward = FALSE,
+                                     s.@is_backward = FALSE
+                           HAVING s.@detached == FALSE;
+
+                @@s_cid_map.clear();
+                @@f_cid_map.clear();
+                @@b_cid_map.clear();
+                @@n_cid_map.clear();
+        END;
+  
+  // result
+        v_all = SELECT s
+                FROM v_all:s 
+                POST-ACCUM @@cluster_size_map += (s.@cid -> 1);
+  
+	FOREACH (cid, csize) IN @@cluster_size_map DO
+		@@cluster_dist_map += (csize -> 1);
+	END;
+	FOREACH (csize, number) IN @@cluster_dist_map DO
+		@@cluster_dist_heap += cluster_num(csize, number);
+	END;
+        PRINT @@cluster_dist_heap;
+
+        IF file_path != "" THEN
+            f.println("Vertex_ID","Component_ID");
+        END;
+
+        v_all = SELECT s
+                FROM v_all:s 
+                POST-ACCUM 
+                IF attr != "" THEN s.setAttr(attr, s.@cid) END,
+                IF file_path != "" THEN f.println(s, s.@cid) END
+                LIMIT output_limit;
+        
+        IF print_accum THEN
+            PRINT v_all[v_all.@cid];
+        END;
+}

--- a/3.0.0/shortest_ss_any_wt.gsql
+++ b/3.0.0/shortest_ss_any_wt.gsql
@@ -1,0 +1,74 @@
+CREATE QUERY shortest_ss_any_wt (VERTEX source, SET<STRING> v_type, SET<STRING> e_type, STRING weight, INT output_limit, BOOL print_accum=TRUE, STRING dist_attr = "", STRING file_path = "", BOOL display=FALSE){
+/* The Bellman-Ford algorithm for single-Source Shortest Path with edge weights,
+ possibly negative.
+ If any loop in the graph has a net negative weight, the algorithm will exit.
+*/
+
+        FILE f(file_path);
+        MinAccum<FLOAT> @dist;                      # best-known shortest distance FROM source
+        ListAccum<VERTEX> @path;                     # best-known path FROM source
+        OrAccum @visited = false;                   # whether this vertex has been visited
+        OrAccum @@hasNegLoop;                       # Indicates a negative loop is found
+        SetAccum<EDGE> @@edgeSet;                   # list of all edges, if display is needed
+        STRING sourceName;
+        STRING errMsg = "There is a loop with negative length. Shortest path is undefined.";
+        INT maxVal = 1000000000;                   # Should be larger than any possible path
+        EXCEPTION negLoop (40999);
+        VSET = {v_type};
+        Source = {source}; 
+
+  ##### Initialization: Set the best-known distance to a maxValue (pseudo-infinite)
+
+        VSET = SELECT s FROM VSET:s
+               POST-ACCUM s.@dist = maxVal,
+                          s.@path = s;
+        Source = SELECT s FROM Source:s               # The distance FROM s to itself is 0.
+                 POST-ACCUM s.@dist = 0,
+                            s.@visited = true;
+  
+  ##### Do N-1 iterations: Consider whether each edge lowers the best-known distance.
+        FOREACH i IN RANGE[1, VSET.size()-1] DO
+                VSET = SELECT s
+                       FROM VSET:s -(e_type:e)-> :t
+                       ACCUM IF s.@visited THEN
+                                IF s.@dist + e.getAttr(weight, "FLOAT") < t.@dist THEN
+                                        t.@dist = s.@dist + e.getAttr(weight, "FLOAT"),             # @dist is a MinAccum
+                                        t.@path = s.@path + [t]
+                                END,
+                                t.@visited += true
+                             END;
+        END;
+             
+  ##### Check for loops with net negative weight #####
+        VSET = SELECT s
+               FROM VSET:s -(e_type:e)-> :t
+               ACCUM @@hasNegLoop +=s.@dist + e.getAttr(weight, "FLOAT") < t.@dist;
+         
+        IF @@hasNegLoop THEN        
+                RAISE negLoop (errMsg);
+        END;
+  
+        IF file_path != "" THEN
+          f.println("Vertex_ID", "Distance", "Shortest_Path");
+        END;
+  
+  ##### Print the results #####
+          VSET = SELECT s
+               FROM VSET:s
+               POST-ACCUM 
+                  IF dist_attr != "" THEN s.setAttr(dist_attr,s.@dist) END, 
+                  IF file_path != "" THEN f.println(s, s.@dist, s.@path) END
+              LIMIT output_limit;
+                
+        
+        IF print_accum THEN
+          PRINT VSET[VSET.@dist, VSET.@path];
+           IF display THEN
+            VSET = SELECT s
+                  FROM VSET:s -(e_type:e)-> :t
+                    ACCUM @@edgeSet += e;
+            PRINT @@edgeSet;
+       END;
+  
+        END;
+}

--- a/3.0.0/shortest_ss_no_wt.gsql
+++ b/3.0.0/shortest_ss_no_wt.gsql
@@ -1,0 +1,54 @@
+CREATE QUERY shortest_ss_no_wt (VERTEX source, SET<STRING> e_type, INT output_limit, BOOL print_accum = TRUE, STRING attr = "", STRING file_path = "", BOOL display = FALSE){
+/* This query is Single-Source Shortest Path without weights on edges. It calculates the shortest distance from the given vertex source to all other connected vertices, and shows one shortest path between them.   
+The JSON version also show visualization of the network. 
+The attribute version only store the distance into attribute, not the path.
+*/
+
+        FILE f(file_path);
+        MinAccum<INT> @dis;
+        OrAccum @visited;
+        ListAccum<VERTEX> @path;
+        SetAccum<EDGE> @@edgeSet;
+
+  ##### Initialization  #####
+        Source = {source};
+        Source = SELECT s 
+                 FROM Source:s
+                 ACCUM s.@visited += true, 
+                       s.@dis = 0,
+                       s.@path = s; 
+        ResultSet = {source};
+
+  ##### Calculate distances and paths #####
+        WHILE(Source.size()>0) DO
+                Source = SELECT t
+                         FROM Source:s -(e_type:e)-> :t
+                         WHERE t.@visited == false
+                         ACCUM t.@dis += s.@dis + 1,
+                               t.@path = s.@path + [t],
+                               t.@visited += true;
+                ResultSet = ResultSet UNION Source;
+        END;
+
+        IF file_path != "" THEN
+            f.println("Vertex_ID","Distance","Shortest_Path");
+        END;
+
+        ResultSet = SELECT s FROM ResultSet:s 
+                    POST-ACCUM 
+                        IF attr != "" THEN s.setAttr(attr, s.@dis) END,
+                        IF file_path != "" THEN f.println(s, s.@dis, s.@path) END
+                    LIMIT output_limit;
+
+        
+        IF print_accum THEN
+            
+            PRINT ResultSet[ResultSet.@dis, ResultSet.@path];
+            IF display THEN
+
+                ResultSet = SELECT s FROM ResultSet:s -(e_type:e)-> :t
+                ACCUM @@edgeSet += e;
+                PRINT @@edgeSet;
+            END;
+        END;
+}

--- a/3.0.0/shortest_ss_no_wt.gsql
+++ b/3.0.0/shortest_ss_no_wt.gsql
@@ -26,7 +26,8 @@ The attribute version only store the distance into attribute, not the path.
                          WHERE t.@visited == false
                          ACCUM t.@dis += s.@dis + 1,
                                t.@path = s.@path + [t],
-                               t.@visited += true;
+                               t.@visited += true
+                        ORDER BY getvid(t);
                 ResultSet = ResultSet UNION Source;
         END;
 

--- a/3.0.0/shortest_ss_pos_wt.gsql
+++ b/3.0.0/shortest_ss_pos_wt.gsql
@@ -1,0 +1,81 @@
+CREATE QUERY shortest_ss_pos_wt (VERTEX source, SET<STRING> e_type, STRING weight, INT output_limit, BOOL print_accum = TRUE, STRING attr = "", STRING file_path = "", BOOL display = FALSE){
+/* The Bellman-Ford algorithm for single-Source Shortest Path 
+   on directed/undirected graph with positive weight.
+   It will not detect negative cycle in this algorithm. 
+*/
+        TYPEDEF TUPLE<FLOAT dist, VERTEX pred> Path_Tuple;    
+        HeapAccum<Path_Tuple>(1, dist ASC) @minPath;
+        ListAccum<VERTEX> @path;                 # shortest path FROM source
+        SetAccum<EDGE> @@edgeSet;               # list of all edges, if display is needed
+        OrAccum @visited;
+        FILE f(file_path);
+        STRING sourceName;
+        INT iter;
+        BOOL negativeCycle;
+        total = {source};                       # the connected vertices
+        start = {source};
+
+              
+        ##### Get the connected vertices
+        start = SELECT s
+                FROM start:s
+                ACCUM s.@minPath += Path_Tuple(0, s),
+                      s.@visited = TRUE,
+                      s.@path += s;
+        WHILE start.size() > 0 DO
+                start = SELECT t
+                        FROM start:s -(e_type:e)-> :t
+                        WHERE NOT t.@visited
+                        ACCUM t.@visited = TRUE;
+                total = total UNION start;
+        END;
+        
+  ##### Do V-1 iterations: Consider whether each edge lowers the best-known distance.
+        iter = total.size() - 1;    # the max iteration is V-1
+        WHILE TRUE LIMIT iter DO 
+                tmp = SELECT s
+                      FROM total:s -(e_type:e)-> :t
+                      ACCUM 
+                            IF s.@minPath.size()>0 AND s.@minPath.top().dist < GSQL_INT_MAX THEN
+                                t.@minPath += Path_Tuple(s.@minPath.top().dist + e.getAttr(weight, "FLOAT"), s)
+                            END;     
+        END;
+        
+  ##### Calculate the paths #####
+        start = {source};
+        tmp = SELECT s
+              FROM total:s
+              WHERE s != source
+              ACCUM s.@visited = FALSE;
+        WHILE start.size() > 0 LIMIT iter DO # Limit the number of hops
+                start = SELECT t
+                        FROM start:s -(e_type:e)-> :t
+                        WHERE NOT t.@visited
+                        ACCUM IF s == t.@minPath.top().pred THEN 
+                                  t.@visited = TRUE,
+                                  t.@path += s.@path,
+                                  t.@path += t
+                              END;
+        END;
+  
+      
+        IF file_path != "" THEN
+          f.println("Vertex_ID","Distance","Shortest_Path");
+        END;
+  
+        total = SELECT s FROM total:s
+                POST-ACCUM 
+                  IF attr != "" THEN s.setAttr(attr, s.@minPath.top().dist) END,
+                  IF file_path != "" THEN f.println(s, s.@minPath.top().dist, s.@path) END
+                LIMIT output_limit;
+                  
+        IF print_accum THEN
+          PRINT total[total.@minPath.top().dist, total.@path];
+          IF display THEN
+              tmp = SELECT s
+                      FROM total:s -(e_type:e)-> :t
+                      ACCUM @@edgeSet += e;
+              PRINT @@edgeSet;
+          END;
+        END;
+}

--- a/3.0.0/wcc_fast.gsql
+++ b/3.0.0/wcc_fast.gsql
@@ -1,0 +1,196 @@
+CREATE QUERY wcc_fast(SET<STRING> v_type, SET<STRING> e_type, INT output_limit, BOOL print_accum=TRUE, STRING attr = "", STRING file_path=""){
+/*
+ * This query identifies connected components using the algorithm found in section 5.2 of Qin et al.
+ * 2014: http://www-std1.se.cuhk.edu.hk/~hcheng/paper/SIGMOD2014qin.pdf
+ */
+        MapAccum<VERTEX, VERTEX> @@parents_map;
+        MapAccum<VERTEX, MinAccum<VERTEX>> @@temp_parents_map;
+        SumAccum<INT> @subnode_count;
+        MapAccum<VERTEX, AndAccum<BOOL>> @@star_map;
+        SumAccum<INT> @@parent_changed_count;
+        FILE f (file_path);
+
+        MapAccum<INT, INT> @@comp_sizes_map; # we'll compile component sizes here. each component has 1 parent, which will be key in map
+        MinAccum<INT> @cid = 0;   # community id for PRINT
+
+        all_v = {v_type};
+
+        #### FOREST INITIALIZATION ####
+        # Step 1: For each node v, let parent p(v) = min ID of v and each of its neighbors.
+        # Need two SELECTs because the one with edge will not update parent for singletons.
+        all_v = SELECT v FROM all_v:v
+                POST-ACCUM
+                    @@temp_parents_map += (v -> v), @@parent_changed_count += 1
+                ;
+
+        # This SELECT will not return isolated singletons because they won't have any edges
+        T1 =    SELECT v FROM all_v:v -(e_type:e)-> :u
+                ACCUM
+                    @@temp_parents_map += (v -> u)
+                ;
+
+        @@parents_map += @@temp_parents_map;
+
+        # Step 2: For each node v, count the number of its subnodes u such that u != v and p(u) = v. Let c(v) = the number of subnodes of vertex v.
+        T1 =    SELECT v FROM all_v:v -(e_type:e)-> :u
+                ACCUM
+                    IF (@@parents_map.get(u) == v) THEN
+                        v.@subnode_count += 1
+                    END
+                ;
+
+        # Step 3: Eliminate non-isolated singletons - that is, all vertices v such that p(v) = v and c(v) = 0, and there exists another vertex u such that (u, v) is an edge in the graph
+        @@temp_parents_map.clear();
+        non_iso_singletons =    SELECT v FROM all_v:v -(e_type:e)-> :u
+                                WHERE
+                                    @@parents_map.get(v) == v AND v.@subnode_count == 0
+                                ACCUM
+                                    @@temp_parents_map += (v -> u)
+                                ;
+        @@parents_map += @@temp_parents_map;
+
+
+        #### ITERATIVELY UPDATE PARENTS UNTIL EACH COMPONENT IS A SINGLE STAR ####
+        WHILE @@parent_changed_count > 0 DO
+            #### STAR DETECTION ####
+            @@star_map.clear();
+
+            # Rule 1: Let s(v) = 1 if p(v) = p(p(v))
+            # Only root and depth 1 vertices will have s(v) = 1. Everything else will have s(v) = 0.
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        VERTEX parent = @@parents_map.get(v),
+                        IF parent == @@parents_map.get(parent) THEN
+                            @@star_map += (v -> true)
+                        ELSE
+                            @@star_map += (v -> false)
+                        END
+                    ;
+
+            # Rule 2: If s(v) = 1 but v has a grandchild u such that s(u) = 0, then s(v) = 0. This will end up updating root vertices. 
+            not_star_roots =    SELECT u FROM all_v:u
+                                WHERE
+                                    @@star_map.get(u) == false
+                                POST-ACCUM
+                                    @@star_map += (@@parents_map.get(@@parents_map.get(u)) -> false)
+                                ;
+
+            # Rule 3: If s(p(v)) = 0, then s(v) = 0. This will end up updating vertices at depth 1 of trees.
+            not_star_depth1 =   SELECT u FROM all_v:u
+                                WHERE
+                                    @@star_map.get(@@parents_map.get(u)) == false
+                                POST-ACCUM
+                                    @@star_map += (u -> false)
+                                ;
+
+
+            #### STAR HOOKING ####
+            # Step 1: Conditional star hooking
+            @@temp_parents_map.clear();
+
+            connected_nodes =   SELECT v FROM all_v:v -(e_type:e)-> :u
+                                ACCUM
+                                    VERTEX v_parent = @@parents_map.get(v),
+                                    VERTEX u_parent = @@parents_map.get(u),
+                                    IF @@star_map.get(v) == true AND v_parent != u_parent THEN
+                                        IF (getvid(u_parent) < getvid(v_parent)) THEN
+                                            @@temp_parents_map += (v_parent -> u_parent)
+                                        END
+                                    END
+                                ;
+
+
+            # Update the parent for star roots that need to be hooked onto larger tree
+            # Additionally, these roots are no longer stars, nor are the nodes they hook onto,
+            # so update the star map before unconditional hooking. 
+            star_roots =    SELECT v FROM all_v:v
+                            WHERE
+                                @@star_map.get(v) == true AND @@parents_map.get(v) == v
+                            ;
+
+            merged_roots =  SELECT v FROM star_roots:v
+                            WHERE
+                                @@temp_parents_map.containsKey(v)
+                            POST-ACCUM
+                                @@star_map += (v -> false),
+                                @@star_map += (@@temp_parents_map.get(v) -> false)
+                            ;
+            @@parents_map += @@temp_parents_map;
+
+
+            # We need to update the children of stars that have been merged as well - they are now longer part of stars.
+            merged_children =   SELECT v FROM all_v:v
+                                WHERE
+                                    @@star_map.get(v) == true AND @@star_map.get(@@parents_map.get(v)) == false
+                                POST-ACCUM
+                                    @@star_map += (v -> false)
+                                ;
+
+            # Step 2: Unconditional star hooking. Nearly identical, but remaining star roots must be merged,
+            # so we skip the POST-ACCUM in the connected_nodes SELECT statement.
+            # We can also start from original values instead of all_v because each of these values should be a subset of the previous vset.
+            @@temp_parents_map.clear();
+
+            connected_nodes =   SELECT v FROM all_v:v -(e_type:e)-> :u
+                                ACCUM
+                                    VERTEX v_parent = @@parents_map.get(v),
+                                    VERTEX u_parent = @@parents_map.get(u),
+                                    IF @@star_map.get(v) == true AND v_parent != u_parent THEN
+                                            @@temp_parents_map += (v_parent -> u_parent)
+                                    END
+                                ;
+
+            star_roots =    SELECT v FROM star_roots:v
+                            WHERE
+                                @@star_map.get(v) == true AND @@parents_map.get(v) == v
+                            ;
+            merged_roots =  SELECT v FROM star_roots:v
+                            WHERE
+                                @@temp_parents_map.containsKey(v)
+                            POST-ACCUM
+                                @@star_map += (v -> false),
+                                @@star_map += (@@temp_parents_map.get(v) -> false)
+                            ;
+            @@parents_map += @@temp_parents_map;
+
+
+            merged_children =   SELECT v FROM all_v:v # Same efficiency question as above
+                                WHERE
+                                    @@star_map.get(v) == true AND @@star_map.get(@@parents_map.get(v)) == false
+                                POST-ACCUM
+                                    @@star_map += (v -> false)
+                                ;
+
+            #### POINTER UPDATES ####
+            # We will now reduce the depth of the remaining trees by changing making each vertex's grandparent
+            # its new parent.
+            @@parent_changed_count = 0;
+            all_v = SELECT v FROM all_v:v
+                    POST-ACCUM
+                        VERTEX parent = @@parents_map.get(v),
+                        VERTEX grandparent = @@parents_map.get(parent),
+                        IF parent != grandparent THEN
+                            @@parent_changed_count += 1,
+                            @@parents_map += (v -> grandparent)
+                        END
+                    ;
+        END;
+
+        IF file_path != "" THEN
+            f.println("Vertex_ID", "Component_ID");
+        END;
+
+         all_v = SELECT v FROM all_v:v
+                POST-ACCUM 
+                IF attr != "" THEN v.setAttr(attr,getvid(@@parents_map.get(v))) END,
+                IF print_accum THEN v.@cid = getvid(@@parents_map.get(v)), 
+                    @@comp_sizes_map += (getvid(@@parents_map.get(v)) -> 1) END,
+                IF file_path != "" THEN f.println(v, getvid(@@parents_map.get(v))) END
+                LIMIT output_limit;
+                
+
+    IF print_accum THEN
+        PRINT @@comp_sizes_map.size() AS num_components, @@comp_sizes_map AS comp_sizes;
+        PRINT all_v[all_v.@cid];
+    END;
+}


### PR DESCRIPTION
I took nearly all of the queries from the templates and converted them to schema less queries with the new release of TigerGraph 3.0 dynamic querying. 

The queries I have not converted are:

- **tri_count** Reason: This was one of the queries that used neighbors() with an edge type passed in. I just realized how to do it using a subquery and without neighbors. I will explore a more efficient way to write this query without using neighbors in the coming days.
- **tri_count_fast** Reason: The same reason as for **tri_count**.

Please review my implementation of the **kcore** algorithm. 

Moreover, a new algorithm called **Maximal Independent Set** or **maximal_indep_set.gsql** was also added to the library.