### PR TITLE
correct the pair-dependencies by exchanging node w and its predecesso…

### DIFF
--- a/algorithms/schema-free/bc_subquery.gsql
+++ b/algorithms/schema-free/bc_subquery.gsql
@@ -35,8 +35,8 @@ returns a map of (s.id->s.@delta)
 	WHILE (@@currDist>0) DO
 		@@currDist += -1;
 		Start = SELECT s FROM Start:s -(e_type:e)-> v_type:t
-				WHERE t.@dist == s.@dist-1
-				ACCUM t.@delta += t.@sigma/s.@sigma*(1+s.@delta);
+				WHERE s.@dist == t.@dist-1
+				ACCUM s.@delta += s.@sigma/t.@sigma*(1+t.@delta);
   
 		Start = SELECT s FROM All:s
 				WHERE s.@dist == @@currDist;	         
@@ -44,10 +44,10 @@ returns a map of (s.id->s.@delta)
 
 	Start = SELECT s FROM All:s
 			ACCUM
-				CASE WHEN s!=source THEN
-						@@MapDelta += (s->s.@delta/2)
-				ELSE @@MapDelta += (s->0)
-				END;
-
+				#CASE WHEN s!=source THEN
+				#		@@MapDelta += (s->s.@delta/2)
+				#ELSE @@MapDelta += (s->0)
+				#END;
+                                @@MapDelta += (s->s.@delta);
 	return @@MapDelta;
  }


### PR DESCRIPTION
According to the paper: "A Faster Algorithm for Betweenness Centrality", Ulrik Brandes had proposed on Journal of Mathematical Sociology. The node v should be predecessor of w (in bc_subquery.gsql is a and t), but in line 37 to 39, the direction  is wrong, so I exchange s and t, and the result of betweenness centrality is correct.