### PR TITLE
Fix typo for weakly_connected_components

### DIFF
--- a/algorithms/Community/connected_components/weakly_connected_components/tg_wcc.gsql
+++ b/algorithms/Community/connected_components/weakly_connected_components/tg_wcc.gsql
@@ -27,7 +27,7 @@ CREATE QUERY tg_wcc (SET<STRING> v_type, SET<STRING> e_type, INT output_limit = 
 			S = SELECT t
 				FROM S:s -(e_type:e)- v_type:t
 				ACCUM t.@cc_id += s.@cc_id // If s has smaller id than t, copy the id to t
-				HAVING t.@cc_id != t.@cc_id'
+				HAVING t.@cc_id != t.@cc_id
 			;
 	END;
 


### PR DESCRIPTION
Removing redundant `'` causing a syntax error in query weakly_connected_components.