### PR TITLE
Jaccard Performance Update

### DIFF
--- a/algorithms/Similarity/jaccard/tg_jaccard_nbor_ap_batch.gsql
+++ b/algorithms/Similarity/jaccard/tg_jaccard_nbor_ap_batch.gsql
@@ -1,11 +1,12 @@
 CREATE QUERY tg_jaccard_nbor_ap_batch (
   INT topK = 10,
-  STRING v_type,
-  STRING feat_v_type,
-  STRING e_type,
-  STRING re_type,
+  SET<STRING> v_type,
+  SET<STRING> feat_v_type,
+  SET<STRING> e_type,
+  SET<STRING> re_type,
   STRING similarity_edge,
-  INT num_of_batches = 10,
+  INT src_batch_num = 50,
+  INT nbor_batch_num = 10,
   BOOL print_accum = true,
   INT print_limit = 50,
   STRING file_path = "") {
@@ -20,69 +21,89 @@ CREATE QUERY tg_jaccard_nbor_ap_batch (
       e_type  : edge type from source vertex to feature vertex type
       re_type  : edge type from feature vertex to source vertex
       similarity_edge : edge type for storing vertex-vertex similarity scores
-      num_of_batches  : how many batches to split the computation into (trade off parallelism for memory optimization)
+      src_batch_num  : how many batches to split the source vertices into
+      nbor_batch_num : how many batches to split the 2-hop neighbor vertices into
       print_accum : print JSON output
-      print_limit : number of source vertices to print
+      print_limit : number of source vertices to print, -1 to print all
       file_path : file to write CSV output to
   */
 
   TYPEDEF TUPLE<VERTEX ver, FLOAT val> Res_Tup; // storing results in the Heap
-  MapAccum<VERTEX, INT> @@set_size_all, @intersection_size; // set sizes of all vertices
+  MapAccum<VERTEX, INT> @@set_size_map, @intersection_size_map; // set sizes of all vertices
+  SetAccum<STRING> @@all_e_types_set;
+  SumAccum<FLOAT> @outdegree;
   HeapAccum<Res_Tup>(topK, val desc) @sim_heap; // stores topK similarity results
   FILE f (file_path);
+  INT print_count;
 
-  Start = {v_type.*};
+  all_vertices = {v_type};
 
-  // store number of features for each source vertex
-  Start = SELECT s
-          FROM Start:s
-          ACCUM
-            @@set_size_all += (s -> s.outdegree(e_type));
+  all_vertices =
+    SELECT s FROM all_vertices:s -(e_type:e)- v_type:t
+    ACCUM s.@outdegree += 1;
 
-  // store number of source vertices that share common features
-  CommonFeatures = SELECT t
-             FROM Start:s-(e_type:e)-feat_v_type:t
-             ACCUM t.@intersection_size += (s -> 1);
+  FOREACH i IN RANGE[0, src_batch_num-1] DO
+    // store number of features for each source vertex
+    src_batch =
+      SELECT s FROM all_vertices:s
+      WHERE getvid(s) % src_batch_num == i
+      ACCUM
+        @@set_size_map += (s -> s.@outdegree);
 
-  // source vertices are split into batches to prevent memory overload
-  FOREACH i IN RANGE[0,num_of_batches-1] DO
-    Others = SELECT t
-            FROM CommonFeatures:s-(re_type:e)-v_type:t
-            WHERE getvid(t) % num_of_batches == i
-            ACCUM
-              t.@intersection_size += s.@intersection_size
-            POST-ACCUM
-              // perform similarity computation and store results
-              FOREACH (k,v) IN t.@intersection_size DO
-                IF k == t THEN
-                  CONTINUE
-                END,
-                FLOAT div = @@set_size_all.get(k) + t.outdegree(e_type) - v,
-                IF div > 0 THEN
-                  t.@sim_heap += Res_Tup(k, v/div)
-                END
-              END,
-              t.@intersection_size.clear();
-  END;
+    // store number of source vertices that share common features
+    common_features =
+      SELECT t FROM src_batch:s-(e_type:e)-feat_v_type:t
+      ACCUM t.@intersection_size_map += (s -> 1);
 
-  // optionally output to file and/or insert edge
-  Results = SELECT s
-          FROM Start:s
-          POST-ACCUM
-            FOREACH tup IN s.@sim_heap DO
-              CASE WHEN tup.val > 0 THEN
-                  IF file_path != "" THEN
-                    f.println(s, tup.ver, tup.val)
-                  END,
-                  IF similarity_edge != "" THEN
-                    INSERT INTO EDGE similarity_edge VALUES (t, tup.ver, tup.val)
-                  END
-              END
-            END;
+    FOREACH j IN RANGE[0, nbor_batch_num-1] DO
+      others =
+        SELECT t FROM common_features:s-(re_type:e)-v_type:t
+        WHERE getvid(t) % nbor_batch_num == j
+        ACCUM
+          t.@intersection_size_map += s.@intersection_size_map;
+      others =
+        SELECT s FROM others:s
+        ACCUM
+          // perform similarity computation and store results
+          FLOAT div = 0,
+          FOREACH (k,v) IN s.@intersection_size_map DO
+            IF k == s THEN
+              CONTINUE
+            END,
+            div = @@set_size_map.get(k) + s.@outdegree - v,
+            IF div > 0 THEN
+              k.@sim_heap += Res_Tup(s, v/div)
+            END
+          END
+        POST-ACCUM
+          s.@intersection_size_map.clear();
+    END;
 
-  // optionally print JSON output
-  IF print_accum THEN
-    Start = SELECT s FROM Start:s WHERE s.@sim_heap.size() > 0 LIMIT print_limit;
-    PRINT Start[Start.@sim_heap];
+    IF print_accum == TRUE THEN
+      IF print_limit == -1 THEN
+        PRINT src_batch[src_batch.@sim_heap];
+      ELSE
+        IF print_count < print_limit THEN
+          print_batch = SELECT s FROM src_batch:s LIMIT print_limit - print_count;
+          print_count = print_count + src_batch.size();
+          PRINT print_batch[print_batch.@sim_heap];
+        END;
+      END;
+    END;
+
+    src_batch =
+      SELECT s FROM src_batch:s
+      POST-ACCUM
+        FOREACH tup IN s.@sim_heap DO
+          IF file_path != "" THEN
+            f.println(s, tup.ver, tup.val)
+          END,
+          IF similarity_edge != "" THEN
+            INSERT INTO EDGE similarity_edge VALUES (s, tup.ver, tup.val)
+          END
+        END,
+        s.@sim_heap.clear();
+
+    @@set_size_map.clear();
   END;
 }


### PR DESCRIPTION
Add batching to source and neighboring vertices. This will allow Jaccard Similarity to be way more scalable, since batching helps prevent memory-overloading.

Testing was performed by Abudula Aisikaer using the bigtest framework. Attached is the output from 1 of 12 test cases.

[Jaccard C10 result.docx](https://github.com/tigergraph/gsql-graph-algorithms/files/7570476/Jaccard.C10.result.docx)
