### PR TITLE
fast random projection gsql - updates to parameter implementation

### DIFF
--- a/algorithms/GraphML/Embeddings/FastRP/tg_fastRP.gsql
+++ b/algorithms/GraphML/Embeddings/FastRP/tg_fastRP.gsql
@@ -260,8 +260,7 @@ CREATE QUERY tg_fastRP(
     POST-ACCUM
     FOREACH i IN RANGE[0, embedding_dimension-1] DO
       s.@final_embedding_list += s.@final_embedding_arr.get(i) / @@weights.size() // Average by # of iterations
-    END,
-    s.@final_embedding_arr.clear();
+    END;
 
   IF print_results THEN
     res = SELECT a FROM verts:a;

--- a/algorithms/GraphML/Embeddings/FastRP/tg_fastRP.gsql
+++ b/algorithms/GraphML/Embeddings/FastRP/tg_fastRP.gsql
@@ -273,4 +273,8 @@ CREATE QUERY tg_fastRP(
   IF result_attribute != "" THEN
     storeEmbeddings = SELECT s FROM verts:s POST-ACCUM s.setAttr(result_attribute, s.@final_embedding_list);
   END;
+
+  sample_verts =
+    SELECT s FROM verts:s LIMIT choose_k;
+  PRINT sample_verts;
 }


### PR DESCRIPTION
### PR Summary
This PR addresses two bugs in query `tg_fastRP.gsql`.

1.  **Parameter `choose_k` ineffective**

- Initially implemented in commit [33bde5e](https://github.com/tigergraph/gsql-graph-algorithms/commit/33bde5e077820651374e56ee84b0e487f2fc040b), the GSQL for this parameter was removed in commit [4a12d01](https://github.com/tigergraph/gsql-graph-algorithms/commit/4a12d0145d9c5e6657a0aaa3b11e1df5d3f9ea13).
- This bug has been resolved by reintroducing the GSQL from commit [33bde5e](https://github.com/tigergraph/gsql-graph-algorithms/commit/33bde5e077820651374e56ee84b0e487f2fc040b).

2. **Incorrect zero values when  `print_results = TRUE`**

- This occurs because of the line `s.@final_embedding_arr.clear()`, which clears the accumulator values before printing.
- This bug has been resolved by removing `s.@final_embedding_arr.clear()`. This line was likely introduced to minimize memory consumption. However, its impact is likely minimal as it occurs towards the end of the script.

### Additional Information

- Testing: The changes have been tested locally.
- Impact on Existing Features: No impact on existing features or new dependencies introduced.

### Feedback Request

- Open for feedback regarding the removal of s.@final_embedding_arr.clear() and its potential impact on memory consumption.