### PR TITLE
[GLE-7418] fix(install): move gsql temp folder into data folder;

### DIFF
--- a/tools/scripts/bash_functions
+++ b/tools/scripts/bash_functions
@@ -151,7 +151,8 @@ function decrypt () {
   else
     QNAME=$1
   fi
-  codegen_path="$(getAppRoot)/dev/gdk/gsql/.tmp/codeGen"
+  version=$(basename "$(getAppRoot)")
+  codegen_path="$(gadmin config get System.DataRoot)/gsql/${version}/.tmp/codeGen"
   if [[ x$QNAME != x ]]
   then
     FILES=$(ls ${codegen_path}/*$QNAME.cpp 2>/dev/null)
@@ -181,7 +182,8 @@ function _complete_decrypt {
   fi
 
   local cur=${COMP_WORDS[COMP_CWORD]}
-  local QUERIES=$(ls $(getAppRoot)/dev/gdk/gsql/.tmp/codeGen/${cur}*.cpp 2>/dev/null)
+  local version=$(basename "$(getAppRoot)")
+  local QUERIES=$(ls "$(gadmin config get System.DataRoot)/gsql/${version}/.tmp/codeGen/${cur}*.cpp" 2>/dev/null)
 
   for QUERY in $QUERIES; do
     local filename=$(basename $QUERY)


### PR DESCRIPTION
<!-- Please enter a brief description/summary of your PR here, e.g. -->
### PR Summary
* https://graphsql.atlassian.net/browse/GLE-7418
  * After restart k8s container, the file generated under folder /home/tigergraph/tigergraph/app/4.0.0/dev/gdk/gsql/.tmp/ will lost, because we’re unable to persist the VERSION folder on K8s since different version has different paths.

<!-- Please review the items on the PR checklist before submitting. -->
### PR Checklist
* [ ] Added comments for more comprehensible code.
* [ ] Added unit and/or regression tests.
* [ ] (Optional) Notified Doc/Prod team, if this PR contains any new features. 

<!-- (Optional) Please provide descriptions about the behavior changes. -->
### What is the behavior change?


<!-- (Optional) Please provide any additional comments. -->
### Other information:


<!-- (Optional) Please provide any related PRs. -->
### Related PRs:
