### PR TITLE
fix(algo): apply tg_wcc print_limit to the component maps

### DIFF
--- a/algorithms/Community/connected_components/weakly_connected_components/standard/tg_wcc.gsql
+++ b/algorithms/Community/connected_components/weakly_connected_components/standard/tg_wcc.gsql
@@ -39,7 +39,7 @@ CREATE QUERY tg_wcc (SET<STRING> v_type_set, SET<STRING> e_type_set, INT print_l
         display_edges:
             output edges for visualization
         print_limit:
-            maximum number of vertices to output (-1 = all)
+            maximum number of vertices and of components to output (-1 = all)
     */
 
 /*
@@ -48,12 +48,14 @@ CREATE QUERY tg_wcc (SET<STRING> v_type_set, SET<STRING> e_type_set, INT print_l
   v_type_set: vertex types to traverse          print_results: print JSON output
   e_type_set: edge types to traverse            result_attribute: INT attribute to store results to
   file_path: file to write CSV output to    display_edges: output edges for visualization
-  print_limit: max #vertices to output (-1 = all)  
+  print_limit: max #vertices and #components to output (-1 = all)
 */
 
 MinAccum<INT> @min_cc_id = 0;       //each vertex's tentative component id
 MapAccum<INT, INT> @@comp_sizes_map;
+MapAccum<INT, INT> @@print_comp_sizes_map;   //@@comp_sizes_map truncated to print_limit
 MapAccum<INT, ListAccum<INT>> @@comp_group_by_size_map;
+SumAccum<INT> @@printed_comp_count;
 FILE f(file_path); 
 
 Start = {v_type_set};
@@ -95,11 +97,17 @@ IF print_results THEN
                 FROM Start:s 
                 LIMIT print_limit;
     END;
+    # print_limit also bounds the per-component maps: they grow with the number
+    # of components, so leaving them uncapped can exceed the response size limit
     FOREACH (compId,size) IN @@comp_sizes_map DO
-        @@comp_group_by_size_map += (size -> compId);
+        IF print_limit < 0 OR @@printed_comp_count < print_limit THEN
+            @@print_comp_sizes_map += (compId -> size);
+            @@comp_group_by_size_map += (size -> compId);
+            @@printed_comp_count += 1;
+        END;
     END;
     PRINT @@comp_group_by_size_map;
-    PRINT @@comp_sizes_map as sizes;
+    PRINT @@print_comp_sizes_map as sizes;
     PRINT Start[Start.@min_cc_id];
 END;
 }

--- a/tests/test/test_community.py
+++ b/tests/test/test_community.py
@@ -73,3 +73,31 @@ class TestCommunity:
                     found = True
             if not found:
                 pytest.fail()
+
+    def run_wcc(self, print_limit):
+        params = {
+            "v_type_set": ["V20"],
+            "e_type_set": ["Empty"],
+            "print_limit": print_limit,
+            "print_results": True,
+            "result_attribute": "",
+            "file_path": "",
+        }
+        result = self.feat.runAlgorithm("tg_wcc", params=params)
+        sizes = [r for r in result if "sizes" in r][0]["sizes"]
+        vertices = [r for r in result if "Start" in r][0]["Start"]
+        return sizes, vertices
+
+    @pytest.mark.parametrize("print_limit", [0, 1, 5])
+    def test_wcc_print_limit(self, print_limit):
+        # Empty has no edges, so each of the 20 V20 vertices is its own
+        # component: print_limit has to bound the component maps too, or the
+        # response keeps growing with the component count
+        sizes, vertices = self.run_wcc(print_limit)
+        assert len(sizes) <= print_limit
+        assert len(vertices) <= print_limit
+
+    def test_wcc_print_limit_all(self):
+        sizes, vertices = self.run_wcc(-1)
+        assert len(sizes) == 20
+        assert len(vertices) == 20


### PR DESCRIPTION
This PR proposes applying `tg_wcc`'s `print_limit` to the per-component maps it prints, so a run on a graph with many components stays within the result size limit (Fixes #127). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/279. You can sign in with your GitHub ID to claim ownership of the project.

### What is wrong today

`print_limit` bounds only the printed vertex set. `@@comp_sizes_map` holds one entry per connected component and `@@comp_group_by_size_map` holds every component id grouped by size, and both are printed in full no matter what `print_limit` is set to. On a large sparse graph the component count is the thing that grows, so the part of the response `print_limit` was meant to cap is exactly the part that stays uncapped.

### Reproduction at current HEAD

On `tg_4.4.0_dev` (`c8ca472`), with a stock engine and 20 isolated `V20` vertices — so 20 single-vertex components — `tg_wcc` was installed unmodified and run with `print_limit=5`:

```
docker run -d --name tg -p 9000:9000 tigergraph/community:4.2.4
# ... create graph_algorithms_testing(V20, Empty), upsert 20 V20 vertices, INSTALL QUERY tg_wcc
curl -s 'http://127.0.0.1:9000/query/graph_algorithms_testing/tg_wcc?v_type_set=V20&e_type_set=Empty&print_limit=5'
```

The vertex list honors the limit and the two maps ignore it:

```
Start printed:       5     <- honors print_limit
sizes entries:      20     <- one per component, ignores print_limit
group_by_size ids:  20     <- ignores print_limit
```

On that same 20-component run the two maps are most of the payload, and on a 50-component version of it they were 1228 of the 1719 response bytes at `print_limit=5` against 378 bytes for the capped vertex list. The maps grow with the component count while the capped part does not.

### The change

The `FOREACH` that builds the grouped map now stops after `print_limit` components and fills a `@@print_comp_sizes_map` alongside it, which is what gets printed as `sizes`. `print_limit < 0` keeps the documented "print everything" path, so existing callers are unaffected. The parameter comments were updated to say the limit covers components as well as vertices. Nothing in the traversal, the `result_attribute` write path or the `file_path` CSV path is touched.

### Verification

Same engine, same graphs, before and after. With `print_limit=-1` the full response is byte-identical to the pre-change run (10847 bytes on the 60-component graph), and every vertex's component assignment is unchanged at every limit — the capped maps are strict subsets of the uncapped ones, so no value is altered, only omitted. Edge values behave: `print_limit` of 0, 1, 59, 60 and 1000 against 60 components return 0, 1, 59, 60 and 60 entries, and `print_results=false` still prints nothing.

`tests/test/test_community.py` gains `test_wcc_print_limit` over the `Empty` graph, where every vertex is its own component. Against the unmodified query the three limits fail and the `-1` case passes:

```
FAILED test/test_community.py::TestCommunity::test_wcc_print_limit[0] - assert 20 <= 0
FAILED test/test_community.py::TestCommunity::test_wcc_print_limit[1] - assert 20 <= 1
FAILED test/test_community.py::TestCommunity::test_wcc_print_limit[5] - assert 20 <= 5
3 failed, 1 passed
```

With the change applied, `4 passed`. Running the whole of `test_community.py` before and after leaves the same 15 `test_lcc*` failures either way — those look for `data/baseline/graph_algorithms_baselines/...`, which is not in the repo — so this adds no new failures.

### How this was managed

This work was tracked as [tg_wcc query parameter output_limit not effective](https://eastagiletracker.com/projects/279/stories/168584) on a board at https://eastagiletracker.com/projects/279 that was imported from this repository's own issues and pull requests — 185 of them — and used to manage the change.

![board](https://raw.githubusercontent.com/eastagiletracker/gsql-graph-algorithms/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
